### PR TITLE
refactor: use browser modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4169,6 +4169,14 @@
           "dev": true,
           "requires": {
             "is-buffer": "^1.1.5"
+          },
+          "dependencies": {
+            "is-buffer": {
+              "version": "1.1.6",
+              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+              "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+              "dev": true
+            }
           }
         }
       }
@@ -4387,6 +4395,14 @@
           "dev": true,
           "requires": {
             "is-buffer": "^1.1.5"
+          },
+          "dependencies": {
+            "is-buffer": {
+              "version": "1.1.6",
+              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+              "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+              "dev": true
+            }
           }
         }
       }
@@ -4407,10 +4423,9 @@
       }
     },
     "is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+      "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -4452,6 +4467,14 @@
           "dev": true,
           "requires": {
             "is-buffer": "^1.1.5"
+          },
+          "dependencies": {
+            "is-buffer": {
+              "version": "1.1.6",
+              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+              "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+              "dev": true
+            }
           }
         }
       }
@@ -4554,6 +4577,14 @@
           "dev": true,
           "requires": {
             "is-buffer": "^1.1.5"
+          },
+          "dependencies": {
+            "is-buffer": {
+              "version": "1.1.6",
+              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+              "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+              "dev": true
+            }
           }
         }
       }
@@ -6583,6 +6614,14 @@
           "dev": true,
           "requires": {
             "is-buffer": "^1.1.5"
+          },
+          "dependencies": {
+            "is-buffer": {
+              "version": "1.1.6",
+              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+              "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+              "dev": true
+            }
           }
         }
       }
@@ -7871,6 +7910,14 @@
           "dev": true,
           "requires": {
             "is-buffer": "^1.1.5"
+          },
+          "dependencies": {
+            "is-buffer": {
+              "version": "1.1.6",
+              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+              "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+              "dev": true
+            }
           }
         }
       }
@@ -8339,6 +8386,14 @@
           "dev": true,
           "requires": {
             "is-buffer": "^1.1.5"
+          },
+          "dependencies": {
+            "is-buffer": {
+              "version": "1.1.6",
+              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+              "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+              "dev": true
+            }
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "API client for Filecoin",
   "main": "src/index.js",
   "browser": {
-    "async-iterator-to-stream": false
+    "async-iterator-to-stream": false,
+    "./src/lib/form-data.js": "./src/lib/form-data.browser.js"
   },
   "scripts": {
     "build": "webpack",
@@ -21,6 +22,7 @@
     "cids": "^0.5.7",
     "explain-error": "^1.0.4",
     "form-data": "^2.3.3",
+    "is-buffer": "^2.0.3",
     "iterable-ndjson": "^1.0.0",
     "multiaddr": "^6.0.5",
     "multiaddr-to-uri": "^4.0.1",

--- a/src/cmd/client/import.js
+++ b/src/cmd/client/import.js
@@ -1,11 +1,7 @@
-/* eslint-env browser */
-
 const toUri = require('multiaddr-to-uri')
-// const toStream = require('async-iterator-to-stream')
-const FormData = require('form-data')
 const CID = require('cids')
 const { ok } = require('../../lib/fetch')
-const { isBrowser, isNode } = require('../../lib/env')
+const { toFormData } = require('../../lib/form-data')
 
 module.exports = (fetch, config) => {
   return async (input, options) => {
@@ -21,42 +17,4 @@ module.exports = (fetch, config) => {
     const data = await res.json()
     return new CID(data['/'])
   }
-}
-
-async function toFormData (input) {
-  // If not an async iterator, this must conform to whatever FormData allows
-  if (!input[Symbol.asyncIterator]) {
-    const formData = new FormData()
-    formData.append('file', input)
-    return formData
-  }
-
-  // In Node.js, FormData can be passed a stream so no need to buffer
-  if (isNode) {
-    const formData = new FormData()
-    const bufs = []
-    for await (const chunk of input) {
-      bufs.push(Buffer.from(chunk))
-    }
-    // FIXME: the below does not work! It should do, but only the first chunk
-    // gets uploaded :(
-    // formData.append('file', toStream(input))
-    formData.append('file', Buffer.concat(bufs))
-    return formData
-  }
-
-  // In the browser there's _currently_ no streaming upload, buffer up our
-  // async iterator chunks and append a big Blob :(
-  if (isBrowser) {
-    // One day, this will be browser streams
-    const formData = new FormData()
-    const bufs = []
-    for await (const chunk of input) {
-      bufs.push(Buffer.isBuffer(chunk) ? chunk.buffer : chunk)
-    }
-    formData.append('file', new Blob(bufs))
-    return formData
-  }
-
-  throw new Error('unknown environment')
 }

--- a/src/lib/env.js
+++ b/src/lib/env.js
@@ -1,7 +1,0 @@
-if (typeof window !== 'undefined' || typeof self !== 'undefined') {
-  // Browser/worker
-  exports.isBrowser = true
-} else if (typeof global !== 'undefined') {
-  // Node.js
-  exports.isNode = true
-}

--- a/src/lib/form-data.browser.js
+++ b/src/lib/form-data.browser.js
@@ -1,0 +1,24 @@
+/* eslint-env browser */
+
+const isBuffer = require('is-buffer')
+
+exports.toFormData = async function toFormData (input) {
+  // If not an async iterator, this must conform to whatever FormData allows
+  if (!input[Symbol.asyncIterator]) {
+    const formData = new FormData()
+    formData.append('file', input)
+    return formData
+  }
+
+  // In the browser there's _currently_ no streaming upload, buffer up our
+  // async iterator chunks and append a big Blob :(
+
+  // One day, this will be browser streams
+  const formData = new FormData()
+  const bufs = []
+  for await (const chunk of input) {
+    bufs.push(isBuffer(chunk) ? chunk.buffer : chunk)
+  }
+  formData.append('file', new Blob(bufs))
+  return formData
+}

--- a/src/lib/form-data.js
+++ b/src/lib/form-data.js
@@ -1,0 +1,23 @@
+// const toStream = require('async-iterator-to-stream')
+const FormData = require('form-data')
+
+exports.toFormData = async function toFormData (input) {
+  // If not an async iterator, this must conform to whatever FormData allows
+  if (!input[Symbol.asyncIterator]) {
+    const formData = new FormData()
+    formData.append('file', input)
+    return formData
+  }
+
+  // In Node.js, FormData can be passed a stream so no need to buffer
+  const formData = new FormData()
+  const bufs = []
+  for await (const chunk of input) {
+    bufs.push(Buffer.from(chunk))
+  }
+  // FIXME: the below does not work! It should do, but only the first chunk
+  // gets uploaded :(
+  // formData.append('file', toStream(input))
+  formData.append('file', Buffer.concat(bufs))
+  return formData
+}


### PR DESCRIPTION
Makes for smaller bundle becuase we can use `is-buffer` instead of including `Buffer` in the bundle.

resolves #8
resolves #9