### PR TITLE
perf: reduce bundle size

### DIFF
--- a/API.md
+++ b/API.md
@@ -87,12 +87,7 @@ for await (const actor of fc.actor.ls())
 After first iteration:
 { actorType: 'MinerActor',
   address: 'fcqpdd3end3j5hhu7lacxg4vnluu9rxfd3nteezw6',
-  code:
-   CID {
-     codec: 'raw',
-     version: 1,
-     multihash:
-      <Buffer 12 20 6e db 35 14 a9 48 c5 1e 7e 0d cc 3f 86 bb 15 42 43 fa b4 54 86 f9 6d dc be bd d7 57 e6 37 35 26> },
+  code: 'zb2rhmciMRS4PBXYBBHssphYKQrbFujVjj1SMyUyN2bU2SKFx',
   nonce: 0,
   balance: '100',
   exports:
@@ -106,12 +101,7 @@ After first iteration:
      getProvingPeriodStart: { Params: [], Return: [Array] },
      submitPoSt: { Params: [Array], Return: [] },
      updatePeerID: { Params: [Array], Return: [] } },
-  head:
-   CID {
-     codec: 'dag-cbor',
-     version: 1,
-     multihash:
-      <Buffer a0 e4 02 20 7c 25 c7 49 04 93 28 60 45 69 05 30 1f cd 10 ba d8 5d b6 85 b9 e1 37 7f 6e c5 2a 70 b8 cf 67 bf> } }
+  head: 'zDPWYqFD5LSWY8NQR7hWtLU8arYBw6W9eXZ1VvWjzh8YUJfAshx4'
 */
 ```
 
@@ -230,13 +220,13 @@ console.log(addr) // fcq7kwnm7mqaynhngfl6qtp03p6jxmyda62zagfek
 
 | Type | Description |
 |------|-------------|
-| `Promise<Multiaddr[]>` | List of bootstrap [multiaddrs](https://github.com/multiformats/js-multiaddr) |
+| `Promise<String[]>` | List of bootstrap [multiaddrs](https://github.com/multiformats/js-multiaddr) |
 
 #### Example
 
 ```js
 const addrs = await fc.boostrap.ls()
-console.log(addrs.map(a => a.toString()))
+console.log(addrs)
 
 /*
 [ '/dns4/test.kittyhawk.wtf/tcp/9001/ipfs/QmXq6XEYeEmUzBFuuKbVEGgxEpVD4xbSkG2Rhek6zkFMp4',
@@ -263,13 +253,13 @@ console.log(addrs.map(a => a.toString()))
 
 | Type | Description |
 |------|-------------|
-| `Promise<CID[]>` | Array of [CID](https://github.com/ipld/js-cid/) objects |
+| `Promise<String[]>` | Array of String CIDs |
 
 #### Example
 
 ```js
 const block = await fc.chain.head()
-console.log(block.map(cid => cid.toString()))
+console.log(block)
 // [ 'zDPWYqFCrhCRdGa1Z84DBpSQ5rrHphwjs7qHe5uS2LFurdnE6vvF' ]
 ```
 
@@ -302,18 +292,13 @@ for await (const block of fc.chain.ls())
 After first iteration:
 [ { miner: 'fcq5y65n23xdkcx2ymakflxpxqhkvewnwswp0me52',
     ticket: 'BNdhwXA6ty/KdYJ3YY/gZ1CexKRXsDYOpBq0wbK+/kA=',
-    parents: [ [CID] ],
+    parents: [ [String] ],
     parentWeightNumerator: 'y8q87bOQCQ==',
     parentWeightDenominator: 'xpSakwY=',
     height: '6hU=',
     nonce: 'AA==',
     messages: [ [Object] ],
-    stateRoot:
-     CID {
-       codec: 'dag-cbor',
-       version: 1,
-       multihash:
-        <Buffer 12 20 22 98 70 56 ae fd bd 3c 46 d9 8e 08 bf 62 8a fb 4e e3 81 73 6f 95 77 d4 48 ec e9 d6 16 a4 db ef> },
+    stateRoot: 'zDPWYqFD5LSWY8NQR7hWtLU8arYBw6W9eXZ1VvWjzh8YUJfAshx4',
     messageReceipts: [ [Object] ] } ]
 */
 ```
@@ -364,7 +349,7 @@ for await (const chunk of fc.client.cat('QmZPUUg1QVMciR1yYnC2HSFrXyAUwRvpnbx4haY
 
 | Type | Description |
 |------|-------------|
-| `Promise<CID>` | CID of the imported content |
+| `Promise<String>` | CID of the imported content |
 
 #### Example
 
@@ -533,7 +518,7 @@ console.log(output.toString()) // Hello World!
 
 | Type | Description |
 |------|-------------|
-| `AsyncIterable<Multiaddr>` | Multiaddresses of a given peer. |
+| `AsyncIterable<String>` | Multiaddresses of a given peer. |
 
 #### Example
 
@@ -545,16 +530,16 @@ for await (const addr of fc.dht.findPeer(peerId))
   console.log(addr)
 
 /*
-[ <Multiaddr 04035ae6b006c34c - /ip4/3.90.230.176/tcp/49996>,
-  <Multiaddr 04035ae6b006c2fd - /ip4/3.90.230.176/tcp/49917>,
-  <Multiaddr 04035ae6b006e3be - /ip4/3.90.230.176/tcp/58302>,
-  <Multiaddr 04035ae6b006232c - /ip4/3.90.230.176/tcp/9004>,
-  <Multiaddr 04035ae6b006c2e1 - /ip4/3.90.230.176/tcp/49889>,
-  <Multiaddr 04035ae6b006c2d0 - /ip4/3.90.230.176/tcp/49872>,
-  <Multiaddr 04035ae6b006dfcc - /ip4/3.90.230.176/tcp/57292>,
-  <Multiaddr 04ac13000e062328 - /ip4/172.19.0.14/tcp/9000>,
-  <Multiaddr 04035ae6b006b461 - /ip4/3.90.230.176/tcp/46177>,
-  <Multiaddr 047f000001062328 - /ip4/127.0.0.1/tcp/9000> ]
+[ '/ip4/3.90.230.176/tcp/49996',
+  '/ip4/3.90.230.176/tcp/49917',
+  '/ip4/3.90.230.176/tcp/58302',
+  '/ip4/3.90.230.176/tcp/9004',
+  '/ip4/3.90.230.176/tcp/49889',
+  '/ip4/3.90.230.176/tcp/49872',
+  '/ip4/3.90.230.176/tcp/57292',
+  '/ip4/172.19.0.14/tcp/9000',
+  '/ip4/3.90.230.176/tcp/46177',
+  '/ip4/127.0.0.1/tcp/9000'
 */
 ```
 
@@ -589,32 +574,27 @@ for await (const res of fc.dht.findProvs('QmbFMke1KXqnYyBBWxB74N4c5SBnJMVAiMNRcG
 Example iteration output:
 { type: 1,
   responses:
-   [ { id: [CID], addrs: [Array] },
-     { id: [CID], addrs: [Array] },
-     { id: [CID], addrs: [Array] },
-     { id: [CID], addrs: [Array] },
-     { id: [CID], addrs: [Array] },
-     { id: [CID], addrs: [Array] },
-     { id: [CID], addrs: [Array] },
-     { id: [CID], addrs: [Array] },
-     { id: [CID], addrs: [Array] },
-     { id: [CID], addrs: [Array] },
-     { id: [CID], addrs: [Array] },
-     { id: [CID], addrs: [Array] },
-     { id: [CID], addrs: [Array] },
-     { id: [CID], addrs: [Array] },
-     { id: [CID], addrs: [Array] },
-     { id: [CID], addrs: [Array] },
-     { id: [CID], addrs: [Array] },
-     { id: [CID], addrs: [Array] },
-     { id: [CID], addrs: [Array] },
-     { id: [CID], addrs: [Array] } ],
-  id:
-   CID {
-     codec: 'dag-pb',
-     version: 0,
-     multihash:
-      <Buffer 12 20 80 ac 25 a4 a1 64 ee 3f 84 13 d1 a3 a7 7b ab fc b8 eb ef 7f 98 99 81 28 e1 0b 00 9f da 99 7e f0> } }
+   [ { id: [String], addrs: [Array] },
+     { id: [String], addrs: [Array] },
+     { id: [String], addrs: [Array] },
+     { id: [String], addrs: [Array] },
+     { id: [String], addrs: [Array] },
+     { id: [String], addrs: [Array] },
+     { id: [String], addrs: [Array] },
+     { id: [String], addrs: [Array] },
+     { id: [String], addrs: [Array] },
+     { id: [String], addrs: [Array] },
+     { id: [String], addrs: [Array] },
+     { id: [String], addrs: [Array] },
+     { id: [String], addrs: [Array] },
+     { id: [String], addrs: [Array] },
+     { id: [String], addrs: [Array] },
+     { id: [String], addrs: [Array] },
+     { id: [String], addrs: [Array] },
+     { id: [String], addrs: [Array] },
+     { id: [String], addrs: [Array] },
+     { id: [String], addrs: [Array] } ],
+  id: 'QmRCrwBopruk3dihfu9njyZ2J88VvCJG4JEnmhNku47RCR'
 */
 ```
 
@@ -635,13 +615,13 @@ Example iteration output:
 
 | Type | Description |
 |------|-------------|
-| `Promise<{ id<CID>, addresses<Multiaddr[]> }>` | TODO describe return value |
+| `Promise<{ id<String>, addresses<String[]> }>` | TODO describe return value |
 
 #### Example
 
 ```js
 const { id, addresses } = await fc.id()
-console.log({ id: id.toString(), addresses: addresses.map(a => a.toString()) })
+console.log({ id, addresses })
 
 /*
 { id: 'QmVESp5X5EtRXGrDBqHzZ1Hd22nSh5QLtw8BozGNu9dWef',
@@ -896,17 +876,12 @@ console.log(block)
 /*
 { miner: '',
   ticket: null,
-  parents: null,
+  parents: 'zDPWYqFCtf5awkxnZbpurnQFvsrafnv4nJbP8UkAHD8GCf8T2Sz4',
   parentWeight: 'AA==',
   height: 'AA==',
   nonce: 'AA==',
   messages: null,
-  stateRoot:
-   CID {
-     codec: 'dag-cbor',
-     version: 1,
-     multihash:
-      <Buffer 12 20 14 7a 88 87 36 57 34 05 49 9d 46 d3 3e 7f fa 95 3e 36 9e 84 b3 8a c8 52 8f 99 7f fb f6 d9 de 84> },
+  stateRoot: 'zdpuAm8mTU17dB5mckEDSNXFtvuxVESUhKivSLCWw1kMZjdK9',
   messageReceipts: null,
   proof:
    [ 0,
@@ -976,7 +951,7 @@ console.log(stats)
 
 ```js
 const res = await fc.swarm.connect('/ip4/192.168.1.1/tcp/6000/ipfs/QmQbd6WxZ3pwcwWn21MvgH1zH4m8hk148kTfoB6BNFa5hK')
-console.log(res.map(p => ({ ...p, peer: p.peer.toString() })))
+console.log(res)
 
 /*
 [ { peer: 'QmQbd6WxZ3pwcwWn21MvgH1zH4m8hk148kTfoB6BNFa5hK',

--- a/package-lock.json
+++ b/package-lock.json
@@ -962,20 +962,6 @@
         "write-file-atomic": "^3.0.0"
       }
     },
-    "babel-eslint": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.0.2.tgz",
-      "integrity": "sha512-UdsurWPtgiPgpJ06ryUnuaSXC2s0WoSZnQmEpbAH65XZSdwowgN5MvyP7e88nW07FYXv72erVtpBkxyDVKhH1Q==",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.0.0",
-        "@babel/traverse": "^7.0.0",
-        "@babel/types": "^7.0.0",
-        "eslint-scope": "3.7.1",
-        "eslint-visitor-keys": "^1.0.0"
-      }
-    },
     "babel-plugin-dynamic-import-node": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz",
@@ -1068,9 +1054,10 @@
       }
     },
     "base-x": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.4.tgz",
-      "integrity": "sha512-UYOadoSIkEI/VrRGSG6qp93rp2WdokiAiNYDfGW5qURAY8GiAQkvMbwNNSDYiVJopqv4gCna7xqf4rrNGp+5AA==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.6.tgz",
+      "integrity": "sha512-4PaF8u2+AlViJxRVjurkLTxpp7CaFRD/jo5rPT9ONnKxyhQ8f59yzamEvq7EkriG56yn5On4ONyaG75HLqr46w==",
+      "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -1258,6 +1245,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
       "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
+      "dev": true,
       "requires": {
         "base-x": "^3.0.2"
       }
@@ -1580,6 +1568,7 @@
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/cids/-/cids-0.7.1.tgz",
       "integrity": "sha512-qEM4j2GKE/BiT6WdUi6cfW8dairhSLTUE8tIdxJG6SvY33Mp/UPjw+xcO0n1zsllgo72BupzKF/44v+Bg8YPPg==",
+      "dev": true,
       "requires": {
         "class-is": "^1.1.0",
         "multibase": "~0.6.0",
@@ -1600,7 +1589,8 @@
     "class-is": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/class-is/-/class-is-1.1.0.tgz",
-      "integrity": "sha512-rhjH9AG1fvabIDoGRVH587413LPjTZgmDF9fOFCbFJQV4yuocX1mHxxvXI4g3cGwbVY9wAYIoKlg1N79frJKQw=="
+      "integrity": "sha512-rhjH9AG1fvabIDoGRVH587413LPjTZgmDF9fOFCbFJQV4yuocX1mHxxvXI4g3cGwbVY9wAYIoKlg1N79frJKQw==",
+      "dev": true
     },
     "class-utils": {
       "version": "0.3.6",
@@ -3029,16 +3019,6 @@
       "integrity": "sha512-OwxJkR6TQiYMmt1EsNRMe5qG3GsbjlcOhbGUBY4LtavF9DsLaTcoR+j2Tdjqi23oUwKNUqX7qcn5fPStafMdlA==",
       "dev": true
     },
-    "eslint-scope": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
-      "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
-      "dev": true,
-      "requires": {
-        "esrecurse": "^4.1.0",
-        "estraverse": "^4.1.1"
-      }
-    },
     "eslint-utils": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.0.tgz",
@@ -4153,7 +4133,8 @@
     "hi-base32": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/hi-base32/-/hi-base32-0.5.0.tgz",
-      "integrity": "sha512-DDRmxSyoYuvjUb9EnXdoiMChBZ7ZcUVJsK5Frd3kqMhuBxvmZdnBeynAVfj7/ECbn++CekcoprvC/rprHPAtow=="
+      "integrity": "sha512-DDRmxSyoYuvjUb9EnXdoiMChBZ7ZcUVJsK5Frd3kqMhuBxvmZdnBeynAVfj7/ECbn++CekcoprvC/rprHPAtow==",
+      "dev": true
     },
     "hmac-drbg": {
       "version": "1.0.1",
@@ -4413,12 +4394,14 @@
     "ip": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
+      "dev": true
     },
     "ip-regex": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
-      "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk="
+      "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
+      "dev": true
     },
     "ipfs-unixfs": {
       "version": "0.1.16",
@@ -4605,6 +4588,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-2.0.0.tgz",
       "integrity": "sha1-aO6gfooKCpTC0IDdZ0xzGrKkYas=",
+      "dev": true,
       "requires": {
         "ip-regex": "^2.0.0"
       }
@@ -5491,6 +5475,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-6.1.0.tgz",
       "integrity": "sha512-+XTP3OzG2m6JVcjxA9QBmGDr0Vk8WwnohC/fCC3puXb5qJqfJwLVJLEtdTc6vK7ri/hw+Nn4wyT4LkZaPnvGfQ==",
+      "dev": true,
       "requires": {
         "bs58": "^4.0.1",
         "class-is": "^1.1.0",
@@ -5500,26 +5485,31 @@
         "varint": "^5.0.0"
       }
     },
-    "multiaddr-to-uri": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/multiaddr-to-uri/-/multiaddr-to-uri-4.0.1.tgz",
-      "integrity": "sha512-RVHKm5NXcMWMIhrwF4B4Q34JtMXt1/2wgnDTnKRE+AGAiXfqFika0bIfCsAtLp+gZJOWeDLeT1vR6P0gGyVAtg==",
-      "requires": {
-        "multiaddr": "^6.0.3"
-      }
-    },
     "multibase": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.6.0.tgz",
       "integrity": "sha512-R9bNLQhbD7MsitPm1NeY7w9sDgu6d7cuj25snAWH7k5PSNPSwIQQBpcpj8jx1W96dLbdigZqmUWOdQRMnAmgjA==",
+      "dev": true,
       "requires": {
         "base-x": "3.0.4"
+      },
+      "dependencies": {
+        "base-x": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.4.tgz",
+          "integrity": "sha512-UYOadoSIkEI/VrRGSG6qp93rp2WdokiAiNYDfGW5qURAY8GiAQkvMbwNNSDYiVJopqv4gCna7xqf4rrNGp+5AA==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "^5.0.1"
+          }
+        }
       }
     },
     "multicodec": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-0.5.4.tgz",
       "integrity": "sha512-0lPLiZ58b2jyXylx2qgda9/6N0YCNIpBxRsZ8sxYayVjEKh58XyNN74VTTQOR/ZCQFgbj0CsqfyRpEDPPlOMkw==",
+      "dev": true,
       "requires": {
         "varint": "^5.0.0"
       }
@@ -5528,6 +5518,7 @@
       "version": "0.4.15",
       "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.15.tgz",
       "integrity": "sha512-G/Smj1GWqw1RQP3dRuRRPe3oyLqvPqUaEDIaoi7JF7Loxl4WAWvhJNk84oyDEodSucv0MmSW/ZT0RKUrsIFD3g==",
+      "dev": true,
       "requires": {
         "bs58": "^4.0.1",
         "varint": "^5.0.0"
@@ -8399,7 +8390,8 @@
     "varint": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.0.tgz",
-      "integrity": "sha1-2Ca4n3SQcy+rwMDtaT7Uddyynr8="
+      "integrity": "sha1-2Ca4n3SQcy+rwMDtaT7Uddyynr8=",
+      "dev": true
     },
     "vm-browserify": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -4,14 +4,13 @@
   "description": "API client for Filecoin",
   "main": "src/index.js",
   "browser": {
-    "async-iterator-to-stream": false,
     "./src/lib/form-data.js": "./src/lib/form-data.browser.js"
   },
   "scripts": {
     "build": "webpack",
     "test": "npm run test:unit",
-    "test:unit": "ava --verbose test/unit/**/*.js test/unit/**/**/*.js",
-    "test:e2e": "node test/e2e/_warn.js && ava --verbose test/e2e/**/*.js",
+    "test:unit": "ava --verbose test/unit/**/*.test.js test/unit/**/**/*.test.js",
+    "test:e2e": "node test/e2e/_warn.js && ava --verbose test/e2e/**/*.test.js",
     "coverage": "nyc --reporter=lcov --reporter=text npm run test:unit",
     "lint": "standard"
   },
@@ -19,19 +18,17 @@
   "license": "(Apache-2.0 OR MIT)",
   "dependencies": {
     "async-iterator-to-stream": "^1.1.0",
-    "cids": "^0.7.1",
     "explain-error": "^1.0.4",
     "form-data": "^2.5.0",
     "is-buffer": "^2.0.3",
     "iterable-ndjson": "^1.1.0",
-    "multiaddr": "^6.1.0",
-    "multiaddr-to-uri": "^4.0.1",
     "node-fetch": "^2.6.0"
   },
   "devDependencies": {
     "ava": "^2.2.0",
-    "babel-eslint": "^10.0.2",
+    "cids": "^0.7.1",
     "ipfs-unixfs": "^0.1.16",
+    "multiaddr": "^6.1.0",
     "nyc": "^14.1.1",
     "standard": "^13.0.2",
     "webpack": "^4.36.1",
@@ -42,9 +39,10 @@
     "compileEnhancements": false,
     "failWithoutAssertions": false
   },
-  "standard": {
-    "parser": "babel-eslint"
-  },
+  "files": [
+    "src",
+    "dist"
+  ],
   "directories": {
     "test": "test"
   },

--- a/src/cmd/actor/ls.js
+++ b/src/cmd/actor/ls.js
@@ -1,8 +1,6 @@
-const toUri = require('multiaddr-to-uri')
-const CID = require('cids')
-const explain = require('explain-error')
-const { ok, toIterable } = require('../../lib/fetch')
 const ndjson = require('iterable-ndjson')
+const toUri = require('../../lib/multiaddr-to-uri')
+const { ok, toIterable } = require('../../lib/fetch')
 
 module.exports = (fetch, config) => {
   return options => (async function * () {
@@ -13,19 +11,11 @@ module.exports = (fetch, config) => {
 
     for await (const actor of ndjson(toIterable(res.body))) {
       if (actor.code) {
-        try {
-          actor.code = new CID(actor.code['/'])
-        } catch (err) {
-          console.warn(explain(err, 'failed to convert actor code CID'))
-        }
+        actor.code = actor.code['/']
       }
 
       if (actor.head) {
-        try {
-          actor.head = new CID(actor.head['/'])
-        } catch (err) {
-          console.warn(explain(err, 'failed to convert actor head CID'))
-        }
+        actor.head = actor.head['/']
       }
 
       yield actor

--- a/src/cmd/address/default.js
+++ b/src/cmd/address/default.js
@@ -1,4 +1,4 @@
-const toUri = require('multiaddr-to-uri')
+const toUri = require('../../lib/multiaddr-to-uri')
 const { ok } = require('../../lib/fetch')
 
 module.exports = (fetch, config) => {

--- a/src/cmd/address/lookup.js
+++ b/src/cmd/address/lookup.js
@@ -1,4 +1,4 @@
-const toUri = require('multiaddr-to-uri')
+const toUri = require('../../lib/multiaddr-to-uri')
 const { ok } = require('../../lib/fetch')
 
 module.exports = (fetch, config) => {

--- a/src/cmd/address/ls.js
+++ b/src/cmd/address/ls.js
@@ -1,4 +1,4 @@
-const toUri = require('multiaddr-to-uri')
+const toUri = require('../../lib/multiaddr-to-uri')
 const { ok } = require('../../lib/fetch')
 
 module.exports = (fetch, config) => {

--- a/src/cmd/address/new.js
+++ b/src/cmd/address/new.js
@@ -1,4 +1,4 @@
-const toUri = require('multiaddr-to-uri')
+const toUri = require('../../lib/multiaddr-to-uri')
 const { ok } = require('../../lib/fetch')
 
 module.exports = (fetch, config) => {

--- a/src/cmd/bootstrap/ls.js
+++ b/src/cmd/bootstrap/ls.js
@@ -1,5 +1,4 @@
-const toUri = require('multiaddr-to-uri')
-const Multiaddr = require('multiaddr')
+const toUri = require('../../lib/multiaddr-to-uri')
 const { ok } = require('../../lib/fetch')
 
 module.exports = (fetch, config) => {
@@ -8,6 +7,6 @@ module.exports = (fetch, config) => {
     const url = `${toUri(config.apiAddr)}/api/bootstrap/ls`
     const res = await ok(fetch(url, { signal: options.signal }))
     const data = await res.json()
-    return data.Peers.map(addr => Multiaddr(addr))
+    return data.Peers || []
   }
 }

--- a/src/cmd/chain/head.js
+++ b/src/cmd/chain/head.js
@@ -1,5 +1,4 @@
-const toUri = require('multiaddr-to-uri')
-const CID = require('cids')
+const toUri = require('../../lib/multiaddr-to-uri')
 const { ok } = require('../../lib/fetch')
 
 module.exports = (fetch, config) => {
@@ -8,6 +7,6 @@ module.exports = (fetch, config) => {
     const url = `${toUri(config.apiAddr)}/api/chain/head`
     const res = await ok(fetch(url, { signal: options.signal }))
     const heads = await res.json()
-    return heads.map(h => new CID(h['/']))
+    return heads.map(h => h['/'])
   }
 }

--- a/src/cmd/chain/ls.js
+++ b/src/cmd/chain/ls.js
@@ -1,8 +1,6 @@
-const toUri = require('multiaddr-to-uri')
-const CID = require('cids')
-const explain = require('explain-error')
-const { ok, toIterable } = require('../../lib/fetch')
 const ndjson = require('iterable-ndjson')
+const toUri = require('../../lib/multiaddr-to-uri')
+const { ok, toIterable } = require('../../lib/fetch')
 
 module.exports = (fetch, config) => {
   return options => (async function * () {
@@ -14,22 +12,11 @@ module.exports = (fetch, config) => {
     for await (const block of ndjson(toIterable(res.body))) {
       yield block.map(b => {
         if (Array.isArray(b.parents)) {
-          b.parents = b.parents.map(p => {
-            try {
-              return new CID(p['/'])
-            } catch (err) {
-              console.warn(explain(err, 'failed to convert parent CID'))
-              return p
-            }
-          })
+          b.parents = b.parents.map(p => p['/'])
         }
 
         if (b.stateRoot) {
-          try {
-            b.stateRoot = new CID(b.stateRoot['/'])
-          } catch (err) {
-            console.warn(explain(err, 'failed to convert state root CID'))
-          }
+          b.stateRoot = b.stateRoot['/']
         }
 
         return b

--- a/src/cmd/client/cat.js
+++ b/src/cmd/client/cat.js
@@ -1,4 +1,4 @@
-const toUri = require('multiaddr-to-uri')
+const toUri = require('../../lib/multiaddr-to-uri')
 const { ok, toIterable } = require('../../lib/fetch')
 
 module.exports = (fetch, config) => {

--- a/src/cmd/client/import.js
+++ b/src/cmd/client/import.js
@@ -1,5 +1,4 @@
-const toUri = require('multiaddr-to-uri')
-const CID = require('cids')
+const toUri = require('../../lib/multiaddr-to-uri')
 const { ok } = require('../../lib/fetch')
 const { toFormData } = require('../../lib/form-data')
 
@@ -15,6 +14,6 @@ module.exports = (fetch, config) => {
     }))
 
     const data = await res.json()
-    return new CID(data['/'])
+    return data['/']
   }
 }

--- a/src/cmd/client/list-asks.js
+++ b/src/cmd/client/list-asks.js
@@ -1,4 +1,4 @@
-const toUri = require('multiaddr-to-uri')
+const toUri = require('../../lib/multiaddr-to-uri')
 const { ok, toIterable } = require('../../lib/fetch')
 const ndjson = require('iterable-ndjson')
 

--- a/src/cmd/config/get.js
+++ b/src/cmd/config/get.js
@@ -1,4 +1,4 @@
-const toUri = require('multiaddr-to-uri')
+const toUri = require('../../lib/multiaddr-to-uri')
 const { ok } = require('../../lib/fetch')
 
 module.exports = (fetch, config) => {

--- a/src/cmd/config/set.js
+++ b/src/cmd/config/set.js
@@ -1,4 +1,4 @@
-const toUri = require('multiaddr-to-uri')
+const toUri = require('../../lib/multiaddr-to-uri')
 const explain = require('explain-error')
 const QueryString = require('querystring')
 const { ok } = require('../../lib/fetch')

--- a/src/cmd/dag/get.js
+++ b/src/cmd/dag/get.js
@@ -1,4 +1,4 @@
-const toUri = require('multiaddr-to-uri')
+const toUri = require('../../lib/multiaddr-to-uri')
 const { ok } = require('../../lib/fetch')
 
 module.exports = (fetch, config) => {

--- a/src/cmd/dht/find-peer.js
+++ b/src/cmd/dht/find-peer.js
@@ -1,8 +1,7 @@
-const toUri = require('multiaddr-to-uri')
-const Multiaddr = require('multiaddr')
-const { ok, toIterable } = require('../../lib/fetch')
 const ndjson = require('iterable-ndjson')
 const QueryString = require('querystring')
+const toUri = require('../../lib/multiaddr-to-uri')
+const { ok, toIterable } = require('../../lib/fetch')
 
 module.exports = (fetch, config) => {
   return (peerId, options) => (async function * () {
@@ -14,7 +13,7 @@ module.exports = (fetch, config) => {
     const res = await ok(fetch(url, { signal: options.signal }))
 
     for await (const addr of ndjson(toIterable(res.body))) {
-      yield Multiaddr(addr)
+      yield addr
     }
   })()
 }

--- a/src/cmd/dht/find-provs.js
+++ b/src/cmd/dht/find-provs.js
@@ -1,9 +1,7 @@
-const toUri = require('multiaddr-to-uri')
-const CID = require('cids')
-const Multiaddr = require('multiaddr')
-const { ok, toIterable } = require('../../lib/fetch')
 const ndjson = require('iterable-ndjson')
 const QueryString = require('querystring')
+const toUri = require('../../lib/multiaddr-to-uri')
+const { ok, toIterable } = require('../../lib/fetch')
 
 module.exports = (fetch, config) => {
   return (key, options) => (async function * () {
@@ -22,13 +20,13 @@ module.exports = (fetch, config) => {
       const prov = {
         type: peer.Type,
         responses: (peer.Responses || []).map(r => ({
-          id: new CID(r.ID),
-          addrs: (r.Addrs || []).map(a => Multiaddr(a))
+          id: r.ID,
+          addrs: r.Addrs || []
         }))
       }
 
       if (peer.ID) {
-        prov.id = new CID(peer.ID)
+        prov.id = peer.ID
       }
 
       if (peer.Extra) {

--- a/src/cmd/id.js
+++ b/src/cmd/id.js
@@ -1,6 +1,4 @@
-const toUri = require('multiaddr-to-uri')
-const CID = require('cids')
-const Multiaddr = require('multiaddr')
+const toUri = require('../lib/multiaddr-to-uri')
 const { ok } = require('../lib/fetch')
 
 module.exports = (fetch, config) => {
@@ -9,6 +7,6 @@ module.exports = (fetch, config) => {
     const url = `${toUri(config.apiAddr)}/api/id`
     const res = await ok(fetch(url, { signal: options.signal }))
     const data = await res.json()
-    return { id: new CID(data.ID), addresses: data.Addresses.map(addr => Multiaddr(addr)) }
+    return { id: data.ID, addresses: data.Addresses || [] }
   }
 }

--- a/src/cmd/log/level.js
+++ b/src/cmd/log/level.js
@@ -1,4 +1,4 @@
-const toUri = require('multiaddr-to-uri')
+const toUri = require('../../lib/multiaddr-to-uri')
 const QueryString = require('querystring')
 const { ok } = require('../../lib/fetch')
 

--- a/src/cmd/log/ls.js
+++ b/src/cmd/log/ls.js
@@ -1,4 +1,4 @@
-const toUri = require('multiaddr-to-uri')
+const toUri = require('../../lib/multiaddr-to-uri')
 const { ok } = require('../../lib/fetch')
 
 module.exports = (fetch, config) => {

--- a/src/cmd/log/tail.js
+++ b/src/cmd/log/tail.js
@@ -1,4 +1,4 @@
-const toUri = require('multiaddr-to-uri')
+const toUri = require('../../lib/multiaddr-to-uri')
 const { ok, toIterable } = require('../../lib/fetch')
 const ndjson = require('iterable-ndjson')
 

--- a/src/cmd/mining/stop.js
+++ b/src/cmd/mining/stop.js
@@ -1,4 +1,4 @@
-const toUri = require('multiaddr-to-uri')
+const toUri = require('../../lib/multiaddr-to-uri')
 const { ok } = require('../../lib/fetch')
 
 module.exports = (fetch, config) => {

--- a/src/cmd/ping.js
+++ b/src/cmd/ping.js
@@ -1,4 +1,4 @@
-const toUri = require('multiaddr-to-uri')
+const toUri = require('../lib/multiaddr-to-uri')
 const ndjson = require('iterable-ndjson')
 const QueryString = require('querystring')
 const { ok, toIterable } = require('../lib/fetch')

--- a/src/cmd/show/block.js
+++ b/src/cmd/show/block.js
@@ -1,6 +1,4 @@
-const toUri = require('multiaddr-to-uri')
-const CID = require('cids')
-const explain = require('explain-error')
+const toUri = require('../../lib/multiaddr-to-uri')
 const { ok } = require('../../lib/fetch')
 
 module.exports = (fetch, config) => {
@@ -12,22 +10,11 @@ module.exports = (fetch, config) => {
     const block = await res.json()
 
     if (Array.isArray(block.parents)) {
-      block.parents = block.parents.map(p => {
-        try {
-          return new CID(p['/'])
-        } catch (err) {
-          console.warn(explain(err, 'failed to convert parent CID'))
-          return p
-        }
-      })
+      block.parents = block.parents.map(p => p['/'])
     }
 
     if (block.stateRoot) {
-      try {
-        block.stateRoot = new CID(block.stateRoot['/'])
-      } catch (err) {
-        console.warn(explain(err, 'failed to convert state root CID'))
-      }
+      block.stateRoot = block.stateRoot['/']
     }
 
     return block

--- a/src/cmd/stats/bandwidth.js
+++ b/src/cmd/stats/bandwidth.js
@@ -1,4 +1,4 @@
-const toUri = require('multiaddr-to-uri')
+const toUri = require('../../lib/multiaddr-to-uri')
 const { ok } = require('../../lib/fetch')
 
 module.exports = (fetch, config) => {

--- a/src/cmd/swarm/connect.js
+++ b/src/cmd/swarm/connect.js
@@ -1,6 +1,5 @@
-const toUri = require('multiaddr-to-uri')
-const CID = require('cids')
 const QueryString = require('querystring')
+const toUri = require('../../lib/multiaddr-to-uri')
 const { ok } = require('../../lib/fetch')
 
 module.exports = (fetch, config) => {
@@ -15,7 +14,7 @@ module.exports = (fetch, config) => {
     const data = await res.json()
 
     return (data || []).map(({ Peer, Success }) => ({
-      peer: new CID(Peer),
+      peer: Peer,
       success: Success
     }))
   }

--- a/src/cmd/swarm/peers.js
+++ b/src/cmd/swarm/peers.js
@@ -1,6 +1,5 @@
-const toUri = require('multiaddr-to-uri')
-const Multiaddr = require('multiaddr')
 const QueryString = require('querystring')
+const toUri = require('../../lib/multiaddr-to-uri')
 const { ok } = require('../../lib/fetch')
 
 module.exports = (fetch, config) => {
@@ -25,7 +24,7 @@ module.exports = (fetch, config) => {
     const data = await res.json()
 
     return (data.Peers || []).map(p => {
-      const peerInfo = { addr: Multiaddr(p.Addr).encapsulate(`/ipfs/${p.Peer}`) }
+      const peerInfo = { addr: p.Addr, peer: p.Peer }
 
       if (options.verbose || options.streams) {
         peerInfo.streams = (p.Streams || []).map(s => ({ protocol: s.Protocol }))

--- a/src/cmd/version.js
+++ b/src/cmd/version.js
@@ -1,4 +1,4 @@
-const toUri = require('multiaddr-to-uri')
+const toUri = require('../lib/multiaddr-to-uri')
 const { ok } = require('../lib/fetch')
 
 module.exports = (fetch, config) => {

--- a/src/cmd/wallet/balance.js
+++ b/src/cmd/wallet/balance.js
@@ -1,4 +1,4 @@
-const toUri = require('multiaddr-to-uri')
+const toUri = require('../../lib/multiaddr-to-uri')
 const { ok } = require('../../lib/fetch')
 
 module.exports = (fetch, config) => {

--- a/src/cmd/wallet/export.js
+++ b/src/cmd/wallet/export.js
@@ -1,4 +1,4 @@
-const toUri = require('multiaddr-to-uri')
+const toUri = require('../../lib/multiaddr-to-uri')
 const QueryString = require('querystring')
 const { ok } = require('../../lib/fetch')
 

--- a/src/index.js
+++ b/src/index.js
@@ -49,7 +49,7 @@ module.exports = (fetch, config) => {
       tail: require('./cmd/log/tail')(fetch, config)
     },
     mining: {
-      stop: require('./cmd/mining/stop')(fetch, config),
+      stop: require('./cmd/mining/stop')(fetch, config)
     },
     ping: require('./cmd/ping')(fetch, config),
     show: {

--- a/src/lib/multiaddr-to-uri.js
+++ b/src/lib/multiaddr-to-uri.js
@@ -1,0 +1,14 @@
+module.exports = ma => {
+  const parts = `${ma}`.split('/')
+  const port = getPort(parts)
+  return `${getProtocol(parts)}://${parts[2]}${port == null ? '' : ':' + port}`
+}
+
+function getProtocol (maParts) {
+  return maParts.indexOf('https') === -1 ? 'http' : 'https'
+}
+
+function getPort (maParts) {
+  const tcpIndex = maParts.indexOf('tcp')
+  return tcpIndex === -1 ? null : maParts[tcpIndex + 1]
+}

--- a/test/e2e/bootstrap/ls.test.js
+++ b/test/e2e/bootstrap/ls.test.js
@@ -7,5 +7,5 @@ test('should list bootstrap node addresses', async t => {
 
   const addrs = await fc.bootstrap.ls()
   t.true(Array.isArray(addrs))
-  addrs.forEach(a => t.true(Multiaddr.isMultiaddr(a)))
+  addrs.forEach(a => t.notThrows(() => Multiaddr(a)))
 })

--- a/test/e2e/chain/head.test.js
+++ b/test/e2e/chain/head.test.js
@@ -7,5 +7,5 @@ test('should get chain heads', async t => {
 
   const heads = await fc.chain.head('fcqqr00e38ge3vr90xx7x46gj7hq3dxcl09us08e')
   t.true(Array.isArray(heads))
-  heads.forEach(h => t.true(CID.isCID(h)))
+  heads.forEach(h => t.notThrows(() => new CID(h)))
 })

--- a/test/e2e/client/import.test.js
+++ b/test/e2e/client/import.test.js
@@ -9,7 +9,7 @@ test('should import a buffer', async t => {
   const input = randomBytes(256)
 
   const cid = await fc.client.import(input)
-  t.true(CID.isCID(cid))
+  t.notThrows(() => new CID(cid))
 
   let output = Buffer.alloc(0)
   for await (const chunk of fc.client.cat(cid)) {
@@ -24,7 +24,7 @@ test('should import an async iterable', async t => {
   const input = [randomBytes(256), randomBytes(32), randomBytes(512)]
 
   const cid = await fc.client.import(toAsyncIterable(input))
-  t.true(CID.isCID(cid))
+  t.notThrows(() => new CID(cid))
 
   let output = Buffer.alloc(0)
   for await (const chunk of fc.client.cat(cid)) {

--- a/test/e2e/dag/get.test.js
+++ b/test/e2e/dag/get.test.js
@@ -9,7 +9,7 @@ test('should get a DAG node', async t => {
   const input = randomBytes(256)
 
   const cid = await fc.client.import(input)
-  t.true(CID.isCID(cid))
+  t.notThrows(() => new CID(cid))
 
   const node = await fc.dag.get(cid)
   const meta = UnixFs.unmarshal(Buffer.from(node.data, 'base64'))

--- a/test/e2e/dht/find-provs.test.js
+++ b/test/e2e/dht/find-provs.test.js
@@ -12,16 +12,16 @@ test('should find providers', async t => {
 
   for await (const peer of fc.dht.findProvs(cid, { numProviders: 1 })) {
     if (peer.id) {
-      t.true(CID.isCID(peer.id))
+      t.notThrows(() => new CID(peer.id))
     }
 
     t.true(typeof peer.type === 'number')
 
     peer.responses.forEach((r, j) => {
-      t.true(CID.isCID(r.id))
+      t.notThrows(() => new CID(r.id))
 
       r.addrs.forEach((a, k) => {
-        t.true(Multiaddr.isMultiaddr(a))
+        t.notThrows(() => Multiaddr(a))
       })
     })
 

--- a/test/e2e/id.test.js
+++ b/test/e2e/id.test.js
@@ -6,6 +6,6 @@ test('should get id', async t => {
   const fc = Filecoin()
   const res = await fc.id()
 
-  t.true(CID.isCID(res.id))
+  t.notThrows(() => new CID(res.id))
   t.true(Array.isArray(res.addresses))
 })

--- a/test/e2e/show/block.test.js
+++ b/test/e2e/show/block.test.js
@@ -8,5 +8,5 @@ test('should show block info', async t => {
   const block = await fc.show.block(cid)
 
   t.truthy(block)
-  t.true(CID.isCID(block.stateRoot))
+  t.notThrows(() => new CID(block.stateRoot))
 })

--- a/test/e2e/swarm/peers.test.js
+++ b/test/e2e/swarm/peers.test.js
@@ -7,5 +7,5 @@ test('should list swarm peers', async t => {
   const peers = await fc.swarm.peers()
 
   t.true(Array.isArray(peers))
-  peers.forEach(p => t.true(Multiaddr.isMultiaddr(p.addr)))
+  peers.forEach(p => t.notThrows(() => Multiaddr(p.addr)))
 })

--- a/test/unit/cmd/actor/ls.test.js
+++ b/test/unit/cmd/actor/ls.test.js
@@ -40,7 +40,7 @@ test('should deserialize actor head CID', async t => {
   for await (const actor of fc.actor.ls()) actors.push(actor)
 
   expectedActors.forEach((expectedActor, i) => {
-    t.true(CID.isCID(actors[i].head))
+    t.notThrows(() => new CID(actors[i].head))
     t.is(actors[i].head.toString(), expectedActor.head['/'])
   })
 })
@@ -59,7 +59,7 @@ test('should deserialize actor code CID', async t => {
   for await (const actor of fc.actor.ls()) actors.push(actor)
 
   expectedActors.forEach((expectedActor, i) => {
-    t.true(CID.isCID(actors[i].code))
+    t.notThrows(() => new CID(actors[i].code))
     t.is(actors[i].code.toString(), expectedActor.code['/'])
   })
 })

--- a/test/unit/cmd/chain/ls.test.js
+++ b/test/unit/cmd/chain/ls.test.js
@@ -38,7 +38,7 @@ test('should deserialize parent CIDs', async t => {
   expectedBlocks.forEach((expectedBlock, i) => {
     expectedBlock.forEach((expectedHead, j) => {
       expectedHead.parents.forEach((expectedParent, k) => {
-        t.true(CID.isCID(blocks[i][j].parents[k]))
+        t.notThrows(() => new CID(blocks[i][j].parents[k]))
         t.is(blocks[i][j].parents[k].toString(), expectedParent['/'])
       })
     })
@@ -63,7 +63,7 @@ test('should deserialize state root CID', async t => {
 
   expectedBlocks.forEach((expectedBlock, i) => {
     expectedBlock.forEach((expectedHead, j) => {
-      t.true(CID.isCID(blocks[i][j].stateRoot))
+      t.notThrows(() => new CID(blocks[i][j].stateRoot))
       t.is(blocks[i][j].stateRoot.toString(), expectedHead.stateRoot['/'])
     })
   })

--- a/test/unit/cmd/client/import.test.js
+++ b/test/unit/cmd/client/import.test.js
@@ -1,6 +1,5 @@
 const test = require('ava')
 const { randomBytes } = require('crypto')
-const CID = require('cids')
 const Filecoin = require('../../../../src')
 const { toAsyncIterable } = require('../../../helpers/iterable')
 
@@ -13,8 +12,7 @@ test('should import a buffer', async t => {
 
   const cid = await fc.client.import(input)
 
-  t.true(CID.isCID(cid))
-  t.is(cid.toString(), res['/'])
+  t.is(cid, res['/'])
 })
 
 test('should import a string', async t => {
@@ -26,8 +24,7 @@ test('should import a string', async t => {
 
   const cid = await fc.client.import(input)
 
-  t.true(CID.isCID(cid))
-  t.is(cid.toString(), res['/'])
+  t.is(cid, res['/'])
 })
 
 test('should import an async iterable', async t => {
@@ -38,6 +35,5 @@ test('should import an async iterable', async t => {
   const fc = Filecoin(fetch)
 
   const cid = await fc.client.import(toAsyncIterable(input))
-  t.true(CID.isCID(cid))
-  t.is(cid.toString(), res['/'])
+  t.is(cid, res['/'])
 })

--- a/test/unit/cmd/dht/find-peer.test.js
+++ b/test/unit/cmd/dht/find-peer.test.js
@@ -13,7 +13,7 @@ test('should find multiaddrs of peer', async t => {
 
   let i = 0
   for await (const addr of fc.dht.findPeer('QmWLtQBDSFpfeD3k23rYhsQ8cS7a4WCRNHWz9UvrsaT2UE')) {
-    t.true(Multiaddr.isMultiaddr(addr))
+    t.notThrows(() => Multiaddr(addr))
     t.is(addr.toString(), Fixtures.sample0[i])
 
     i++

--- a/test/unit/cmd/dht/find-provs.test.js
+++ b/test/unit/cmd/dht/find-provs.test.js
@@ -1,5 +1,4 @@
 const test = require('ava')
-const CID = require('cids')
 const Multiaddr = require('multiaddr')
 const Filecoin = require('../../../../src')
 const { toAsyncIterable } = require('../../../helpers/iterable')
@@ -15,18 +14,16 @@ test('should find providers', async t => {
   let i = 0
   for await (const peer of fc.dht.findProvs('QmbFMke1KXqnYyBBWxB74N4c5SBnJMVAiMNRcGu6x1AwQH')) {
     if (peer.id) {
-      t.true(CID.isCID(peer.id))
-      t.is(peer.id.toString(), Fixtures.sample0[i].ID)
+      t.is(peer.id, Fixtures.sample0[i].ID)
     }
 
     t.true(typeof peer.type === 'number')
     t.is(peer.type, Fixtures.sample0[i].Type)
 
     peer.responses.forEach((r, j) => {
-      t.true(CID.isCID(r.id))
-      t.is(r.id.toString(), Fixtures.sample0[i].Responses[j].ID)
+      t.is(r.id, Fixtures.sample0[i].Responses[j].ID)
       r.addrs.forEach((a, k) => {
-        t.true(Multiaddr.isMultiaddr(a))
+        t.notThrows(() => Multiaddr(a))
         t.is(a.toString(), Fixtures.sample0[i].Responses[j].Addrs[k])
       })
     })

--- a/test/unit/cmd/id.test.js
+++ b/test/unit/cmd/id.test.js
@@ -1,5 +1,4 @@
 const test = require('ava')
-const CID = require('cids')
 const Filecoin = require('../../../src')
 
 test('should get id', async t => {
@@ -15,8 +14,7 @@ test('should get id', async t => {
   const fc = Filecoin(fetch)
   const res = await fc.id()
 
-  t.true(CID.isCID(res.id))
-  t.is(res.id.toString(), jsonData.ID)
+  t.is(res.id, jsonData.ID)
   t.true(Array.isArray(res.addresses))
   t.deepEqual(res.addresses.map(a => a.toString()), jsonData.Addresses)
 })

--- a/test/unit/cmd/swarm/connect.test.js
+++ b/test/unit/cmd/swarm/connect.test.js
@@ -1,5 +1,4 @@
 const test = require('ava')
-const CID = require('cids')
 const Filecoin = require('../../../../src')
 
 test('should connect to an address', async t => {
@@ -19,8 +18,7 @@ test('should connect to an address', async t => {
 
   res.forEach((p, i) => {
     t.is(Object.keys(p).length, 2)
-    t.true(CID.isCID(p.peer))
-    t.is(p.peer.toString(), data[i].Peer)
+    t.is(p.peer, data[i].Peer)
     t.is(p.success, data[i].Success)
   })
 })
@@ -49,8 +47,7 @@ test('should connect to multiple addresses', async t => {
 
   res.forEach((p, i) => {
     t.is(Object.keys(p).length, 2)
-    t.true(CID.isCID(p.peer))
-    t.is(p.peer.toString(), data[i].Peer)
+    t.is(p.peer, data[i].Peer)
     t.is(p.success, data[i].Success)
   })
 })

--- a/test/unit/cmd/swarm/peers.test.js
+++ b/test/unit/cmd/swarm/peers.test.js
@@ -1,5 +1,4 @@
 const test = require('ava')
-const Multiaddr = require('multiaddr')
 const Filecoin = require('../../../../src')
 
 test('should list swarm peers', async t => {
@@ -22,9 +21,9 @@ test('should list swarm peers', async t => {
   t.is(peers.length, 1)
 
   peers.forEach((p, i) => {
-    t.is(Object.keys(p).length, 1)
-    t.true(Multiaddr.isMultiaddr(p.addr))
-    t.is(p.addr.toString(), data.Peers[i].Addr + '/ipfs/' + data.Peers[i].Peer)
+    t.is(Object.keys(p).length, 2)
+    t.is(p.addr, data.Peers[i].Addr)
+    t.is(p.peer, data.Peers[i].Peer)
   })
 })
 
@@ -55,9 +54,9 @@ test('should list swarm peers with verbose option', async t => {
   t.is(peers.length, 1)
 
   peers.forEach((p, i) => {
-    t.is(Object.keys(p).length, 4)
-    t.true(Multiaddr.isMultiaddr(p.addr))
-    t.is(p.addr.toString(), data.Peers[i].Addr + '/ipfs/' + data.Peers[i].Peer)
+    t.is(Object.keys(p).length, 5)
+    t.is(p.addr, data.Peers[i].Addr)
+    t.is(p.peer, data.Peers[i].Peer)
     t.is(p.latency, data.Peers[i].Latency)
     t.is(p.muxer, data.Peers[i].Muxer)
     t.true(Array.isArray(p.streams))
@@ -92,9 +91,9 @@ test('should list swarm peers with streams option', async t => {
   t.is(peers.length, 1)
 
   peers.forEach((p, i) => {
-    t.is(Object.keys(p).length, 2)
-    t.true(Multiaddr.isMultiaddr(p.addr))
-    t.is(p.addr.toString(), data.Peers[i].Addr + '/ipfs/' + data.Peers[i].Peer)
+    t.is(Object.keys(p).length, 3)
+    t.is(p.addr, data.Peers[i].Addr)
+    t.is(p.peer, data.Peers[i].Peer)
     t.true(Array.isArray(p.streams))
     t.true(p.streams.every((s, j) => s.protocol === data.Peers[i].Streams[j].Protocol))
   })
@@ -120,9 +119,9 @@ test('should list swarm peers with latency option', async t => {
   t.is(peers.length, 1)
 
   peers.forEach((p, i) => {
-    t.is(Object.keys(p).length, 2)
-    t.true(Multiaddr.isMultiaddr(p.addr))
-    t.is(p.addr.toString(), data.Peers[i].Addr + '/ipfs/' + data.Peers[i].Peer)
+    t.is(Object.keys(p).length, 3)
+    t.is(p.addr, data.Peers[i].Addr)
+    t.is(p.peer, data.Peers[i].Peer)
     t.is(p.latency, data.Peers[i].Latency)
   })
 })


### PR DESCRIPTION
This reduces the bundle size significantly by excluding CID and Multiaddr classes from the bundle.

BREAKING CHANGE: Responses that used to contain CID and Multiaddr instances now contain their string form. If you need utilities from CID or Multiaddr classes, import them into your application bundle and pass response values to them.