### PR TITLE
Adds endpoint api/client/payments

### DIFF
--- a/API.md
+++ b/API.md
@@ -405,13 +405,13 @@ After first iteration:
 
 > List payments for a given deal
 
-### `client.payments([options])`
+### `client.payments(dealCid, [options])`
 
 #### Parameters
 
 | Name | Type | Description |
 |------|------|-------------|
-| channel id | `String` | Channel id from which to list vouchers |
+| dealCid | `CID`\|`String` | Channel id from which to list vouchers |
 | options | `Object` | Optional options |
 | options.signal | [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) | A signal that can be used to abort the request |
 
@@ -421,6 +421,8 @@ After first iteration:
 |------|-------------|
 | `Promise<Object[]>` | List of payments |
 
+#### Example
+
 ```js
 const cid = 'zDPWYqFCuTNxiwRkt1iDJWEy6qKPGCunMGHrP1ojsMrZDWKYsgzF'
 const payments = await fc.client.payments(cid)
@@ -429,13 +431,13 @@ console.log(payments)
 /*
   [
     {
-      "channel":0,
-      "payer":"t1bcvxo4ztdkukjmrsjvc5d4w24cl55vvbrssspyy",
-      "target":"t1uo4nzu44apoclkbjbbvc4f3irbptg3ctjq44wiq",
-      "amount":"25000",
-      "valid_at":8,
-      "condition":null,
-      "signature":"1My76149fPIulbdO/DKlkUBMMSLwGYSw2XmVKXq3HrxMG5kkmBgsaPZ/DzdxiOWX5kdnXJ++AFQqsmWHd5dtOwE="
+      "channel": 0,
+      "payer": "t1bcvxo4ztdkukjmrsjvc5d4w24cl55vvbrssspyy",
+      "target": "t1uo4nzu44apoclkbjbbvc4f3irbptg3ctjq44wiq",
+      "amount": "25000",
+      "validAt": 8,
+      "condition": null,
+      "signature": "1My76149fPIulbdO/DKlkUBMMSLwGYSw2XmVKXq3HrxMG5kkmBgsaPZ/DzdxiOWX5kdnXJ++AFQqsmWHd5dtOwE="
     }
   ]
 */

--- a/API.md
+++ b/API.md
@@ -11,7 +11,7 @@
 * [client.cat](#clientcat)
 * [client.import](#clientimport)
 * [client.listAsks](#clientlistasks)
-* client.payments
+* [client.payments](#clientpayments)
 * client.proposeStorageDeal
 * client.queryStorageDeal
 * [config.get](#configget)
@@ -398,6 +398,46 @@ After first iteration:
   price: '0.00000000000001',
   expiry: 33329,
   id: 4 }
+*/
+```
+
+## `client.payments`
+
+> List payments for a given deal
+
+### `client.payments([options])`
+
+#### Parameters
+
+| Name | Type | Description |
+|------|------|-------------|
+| channel id | `String` | Channel id from which to list vouchers |
+| options | `Object` | Optional options |
+| options.signal | [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) | A signal that can be used to abort the request |
+
+#### Returns
+
+| Type | Description |
+|------|-------------|
+| `Promise<Object[]>` | List of payments |
+
+```js
+const cid = 'zDPWYqFCuTNxiwRkt1iDJWEy6qKPGCunMGHrP1ojsMrZDWKYsgzF'
+const payments = await fc.client.payments(cid)
+console.log(payments)
+
+/*
+  [
+    {
+      "channel":0,
+      "payer":"t1bcvxo4ztdkukjmrsjvc5d4w24cl55vvbrssspyy",
+      "target":"t1uo4nzu44apoclkbjbbvc4f3irbptg3ctjq44wiq",
+      "amount":"25000",
+      "valid_at":8,
+      "condition":null,
+      "signature":"1My76149fPIulbdO/DKlkUBMMSLwGYSw2XmVKXq3HrxMG5kkmBgsaPZ/DzdxiOWX5kdnXJ++AFQqsmWHd5dtOwE="
+    }
+  ]
 */
 ```
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ $ filecoin config api.accessControlAllowOrigin '["http://example.com"]'
 * [client.cat](API.md#clientcat)
 * [client.import](API.md#clientimport)
 * [client.listAsks](API.md#clientlistasks)
-* client.payments
+* [client.payments](API.md#clientpayments)
 * client.proposeStorageDeal
 * client.queryStorageDeal
 * [config.get](API.md#configget)

--- a/src/cmd/client/payments.js
+++ b/src/cmd/client/payments.js
@@ -1,0 +1,15 @@
+const toUri = require('../../lib/multiaddr-to-uri')
+const { ok } = require('../../lib/fetch')
+
+module.exports = (fetch, config) => {
+  return async (cid, options) => {
+    options = options || {}
+    cid = encodeURIComponent(cid)
+
+    const url = `${toUri(config.apiAddr)}/api/client/payments?arg=${cid}`
+    const res = await ok(fetch(url, { signal: options.signal }))
+
+    const paymentsData = await res.json()
+    return paymentsData
+  }
+}

--- a/src/cmd/client/payments.js
+++ b/src/cmd/client/payments.js
@@ -10,6 +10,13 @@ module.exports = (fetch, config) => {
     const res = await ok(fetch(url, { signal: options.signal }))
 
     const paymentsData = await res.json()
-    return paymentsData
+
+    return (paymentsData || []).map(d => {
+      const { valid_at, ...rest } = d
+      if (valid_at != null) {
+        rest.validAt = valid_at
+      }
+      return rest
+    })
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,8 @@ module.exports = (fetch, config) => {
     client: {
       cat: require('./cmd/client/cat')(fetch, config),
       import: require('./cmd/client/import')(fetch, config),
-      listAsks: require('./cmd/client/list-asks')(fetch, config)
+      listAsks: require('./cmd/client/list-asks')(fetch, config),
+      payments: require('./cmd/client/payments')(fetch, config)
     },
     config: {
       get: require('./cmd/config/get')(fetch, config),

--- a/test/unit/cmd/client/payments.test.js
+++ b/test/unit/cmd/client/payments.test.js
@@ -1,0 +1,26 @@
+const test = require('ava')
+const CID = require('cids')
+const Filecoin = require('../../../../src')
+
+test('should list payments for a given deal', async t => {
+  const cid = "zDPWYqFCuTNxiwRkt1iDJWEy6qKPGCunMGHrP1ojsMrZDWKYsgzF"
+  const payments = [
+    {
+      "channel":0,
+      "payer":"t1bcvxo4ztdkukjmrsjvc5d4w24cl55vvbrssspyy",
+      "target":"t1uo4nzu44apoclkbjbbvc4f3irbptg3ctjq44wiq",
+      "amount":"25000",
+      "valid_at":8,
+      "condition":null,
+      "signature":"1My76149fPIulbdO/DKlkUBMMSLwGYSw2XmVKXq3HrxMG5kkmBgsaPZ/DzdxiOWX5kdnXJ++AFQqsmWHd5dtOwE="
+    }
+  ]
+
+  const fetch = () => ({ ok: true, json: () => payments })
+  const fc = Filecoin(fetch)
+
+  const res = await fc.client.payments(cid)
+
+  t.true(Array.isArray(res))
+
+})

--- a/test/unit/cmd/client/payments.test.js
+++ b/test/unit/cmd/client/payments.test.js
@@ -2,16 +2,16 @@ const test = require('ava')
 const Filecoin = require('../../../../src')
 
 test('should list payments for a given deal', async t => {
-  const cid = "zDPWYqFCuTNxiwRkt1iDJWEy6qKPGCunMGHrP1ojsMrZDWKYsgzF"
+  const cid = 'zDPWYqFCuTNxiwRkt1iDJWEy6qKPGCunMGHrP1ojsMrZDWKYsgzF'
   const payments = [
     {
-      "channel":0,
-      "payer":"t1bcvxo4ztdkukjmrsjvc5d4w24cl55vvbrssspyy",
-      "target":"t1uo4nzu44apoclkbjbbvc4f3irbptg3ctjq44wiq",
-      "amount":"25000",
-      "valid_at":8,
-      "condition":null,
-      "signature":"1My76149fPIulbdO/DKlkUBMMSLwGYSw2XmVKXq3HrxMG5kkmBgsaPZ/DzdxiOWX5kdnXJ++AFQqsmWHd5dtOwE="
+      channel: 0,
+      payer: 't1bcvxo4ztdkukjmrsjvc5d4w24cl55vvbrssspyy',
+      target: 't1uo4nzu44apoclkbjbbvc4f3irbptg3ctjq44wiq',
+      amount: 25000,
+      valid_at: 8,
+      condition: null,
+      signature: '1My76149fPIulbdO/DKlkUBMMSLwGYSw2XmVKXq3HrxMG5kkmBgsaPZ/DzdxiOWX5kdnXJ++AFQqsmWHd5dtOwE='
     }
   ]
 
@@ -21,5 +21,15 @@ test('should list payments for a given deal', async t => {
   const res = await fc.client.payments(cid)
 
   t.true(Array.isArray(res))
+  t.is(res.length, payments.length)
 
+  res.forEach((p, i) => {
+    t.is(p.channel, payments[i].channel)
+    t.is(p.payer, payments[i].payer)
+    t.is(p.target, payments[i].target)
+    t.is(p.amount, payments[i].amount)
+    t.is(p.validAt, payments[i].valid_at)
+    t.is(p.condition, payments[i].condition)
+    t.is(p.signature, payments[i].signature)
+  })
 })

--- a/test/unit/cmd/client/payments.test.js
+++ b/test/unit/cmd/client/payments.test.js
@@ -1,5 +1,4 @@
 const test = require('ava')
-const CID = require('cids')
 const Filecoin = require('../../../../src')
 
 test('should list payments for a given deal', async t => {


### PR DESCRIPTION
Adds the endpoint to get payments for a given deal. 

Solves issue here: [#14](https://github.com/filecoin-project/js-filecoin-api-client/issues/14)

**Endpoint**

`api/client/payments`

**Description**
List payments for a given deal

**Arguments**
* arg [string]: Channel id from which to list vouchers Required: yes.

**Response**
On success, the call to this endpoint will return with 200 and the following body:

```
    [
      {
        "channel":0,
        "payer":"t1bcvxo4ztdkukjmrsjvc5d4w24cl55vvbrssspyy",
        "target":"t1uo4nzu44apoclkbjbbvc4f3irbptg3ctjq44wiq",
        "amount":"25000",
        "valid_at":8,
        "condition":null,
        "signature":"1My76149fPIulbdO/DKlkUBMMSLwGYSw2XmVKXq3HrxMG5kkmBgsaPZ/DzdxiOWX5kdnXJ++AFQqsmWHd5dtOwE="
      }
    ]
```

resolves https://github.com/filecoin-project/js-filecoin-api-client/issues/14
