### PR TITLE
Adds endpoint for proposing a storage deal

### DIFF
--- a/API.md
+++ b/API.md
@@ -406,6 +406,7 @@ After first iteration:
 > List payments for a given deal
 
 ### `client.payments(dealCid, [options])`
+
 #### Parameters
 
 | Name | Type | Description |
@@ -415,6 +416,7 @@ After first iteration:
 | options.signal | [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) | A signal that can be used to abort the request |
 
 #### Returns
+
 | Type | Description |
 |------|-------------|
 | `Promise<Object[]>` | List of payments |
@@ -461,10 +463,10 @@ console.log(payments)
 | options.signal | [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) | A signal that can be used to abort the request |
 
 #### Returns
+
 | Type | Description |
 |------|-------------|
 | `Promise<Object>` | Storage deal |
-
 
 #### Example
 
@@ -483,14 +485,14 @@ const storageDealProposal = await fc.client.proposeStorageDeal(miner, cid, askId
 
 /*
 {
-  "State":3,
-  "Message":"",
-  "ProposalCid":
+  "state":3,
+  "message":"",
+  "proposalCid":
     {
       "/":"zDPWYqFCz8vQRUnFVsbdXPAWTRuRBLaPncKLLSqd7cNF3Bd2NQT5"
     },
-  "ProofInfo":null,
-  "Signature":"c2lnbmF0dXJycmVlZQ=="
+  "proofInfo":null,
+  "signature":"c2lnbmF0dXJycmVlZQ=="
 }
 */
 ```

--- a/API.md
+++ b/API.md
@@ -12,7 +12,7 @@
 * [client.import](#clientimport)
 * [client.listAsks](#clientlistasks)
 * [client.payments](#clientpayments)
-* client.proposeStorageDeal
+* [client.proposeStorageDeal](#clientproposestoragedeal)
 * client.queryStorageDeal
 * [config.get](#configget)
 * [config.set](#configset)
@@ -406,7 +406,6 @@ After first iteration:
 > List payments for a given deal
 
 ### `client.payments(dealCid, [options])`
-
 #### Parameters
 
 | Name | Type | Description |
@@ -416,7 +415,6 @@ After first iteration:
 | options.signal | [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) | A signal that can be used to abort the request |
 
 #### Returns
-
 | Type | Description |
 |------|-------------|
 | `Promise<Object[]>` | List of payments |
@@ -440,6 +438,63 @@ console.log(payments)
       "signature": "1My76149fPIulbdO/DKlkUBMMSLwGYSw2XmVKXq3HrxMG5kkmBgsaPZ/DzdxiOWX5kdnXJ++AFQqsmWHd5dtOwE="
     }
   ]
+*/
+```
+
+
+## `client.proposeStorageDeal`
+
+> Propose a storage deal with a storage miner
+
+### `client.proposeStorageDeal(miner, cid, askID, time, allowDuplicates, [options])`
+
+#### Parameters
+
+| Name | Type | Description |
+|------|------|-------------|
+| miner | `String` | Address of miner to send storage proposal |
+| cid | `String` | CID of the data to be stored |
+| id | `String` | ID of ask for which to propose a deal |
+| time | `String` | Time in blocks (about 30 seconds per block) to store data. For example, storing for 1 day (2 blocks/min * 60 min/hr * 24 hr/day) = 2880 blocks. |
+| allowDuplicates | `Boolean` | Allows duplicate proposals to be created. Unless this flag is set, you will not be able to make more than one deal per piece per miner. This protection exists to prevent erroneous duplicate deals. This parameter is not required. |
+| options | `Object` | Optional options |
+| options.signal | [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) | A signal that can be used to abort the request |
+
+#### Returns
+| Type | Description |
+|------|-------------|
+| `Promise<Object>` | Storage deal |
+
+
+#### Example
+
+From a buffer:
+
+```js
+const miner = "t2u2r6nyaxdspozci5t2i2xtfw23lxa35rvkul7di"
+const cid = "QmV9mkND7mvWim77R669UCLg1DgYzqiX1NsXtj7GSydzD6"
+const askId = "0"
+const time = "2800" // 1 day
+
+const storageDealProposal = await fc.client.proposeStorageDeal(miner, cid, askId, time)
+
+// with optional flag to allow duplicates
+const storageDealProposal = await fc.client.proposeStorageDeal(miner, cid, askId, time, { allowDuplicates: true })
+
+// with allow duplicates flag and options, order important
+const storageDealProposal = await fc.client.proposeStorageDeal(miner, cid, askId, time, { allowDuplicates: true }, { signal: "some signal to abort" })
+
+/*
+{
+  "State":3,
+  "Message":"",
+  "ProposalCid":
+    {
+      "/":"zDPWYqFCz8vQRUnFVsbdXPAWTRuRBLaPncKLLSqd7cNF3Bd2NQT5"
+    },
+  "ProofInfo":null,
+  "Signature":"c2lnbmF0dXJycmVlZQ=="
+}
 */
 ```
 

--- a/API.md
+++ b/API.md
@@ -456,8 +456,8 @@ console.log(payments)
 | cid | `String` | CID of the data to be stored |
 | id | `String` | ID of ask for which to propose a deal |
 | time | `String` | Time in blocks (about 30 seconds per block) to store data. For example, storing for 1 day (2 blocks/min * 60 min/hr * 24 hr/day) = 2880 blocks. |
-| allowDuplicates | `Boolean` | Allows duplicate proposals to be created. Unless this flag is set, you will not be able to make more than one deal per piece per miner. This protection exists to prevent erroneous duplicate deals. This parameter is not required. |
 | options | `Object` | Optional options |
+| options.allowDuplicates | `Boolean` | Allows duplicate proposals to be created. Unless this flag is set, you will not be able to make more than one deal per piece per miner. This protection exists to prevent erroneous duplicate deals. This parameter is not required. |
 | options.signal | [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) | A signal that can be used to abort the request |
 
 #### Returns
@@ -480,9 +480,6 @@ const storageDealProposal = await fc.client.proposeStorageDeal(miner, cid, askId
 
 // with optional flag to allow duplicates
 const storageDealProposal = await fc.client.proposeStorageDeal(miner, cid, askId, time, { allowDuplicates: true })
-
-// with allow duplicates flag and options, order important
-const storageDealProposal = await fc.client.proposeStorageDeal(miner, cid, askId, time, { allowDuplicates: true }, { signal: "some signal to abort" })
 
 /*
 {

--- a/API.md
+++ b/API.md
@@ -448,7 +448,7 @@ console.log(payments)
 
 > Propose a storage deal with a storage miner
 
-### `client.proposeStorageDeal(miner, cid, askID, time, allowDuplicates, [options])`
+### `client.proposeStorageDeal(miner, cid, askId, time, [options])`
 
 #### Parameters
 
@@ -456,8 +456,8 @@ console.log(payments)
 |------|------|-------------|
 | miner | `String` | Address of miner to send storage proposal |
 | cid | `String` | CID of the data to be stored |
-| id | `String` | ID of ask for which to propose a deal |
-| time | `String` | Time in blocks (about 30 seconds per block) to store data. For example, storing for 1 day (2 blocks/min * 60 min/hr * 24 hr/day) = 2880 blocks. |
+| askId | `String` | ID of ask for which to propose a deal |
+| time | `Number`\|`String` | Time in blocks (about 30 seconds per block) to store data. For example, storing for 1 day (2 blocks/min * 60 min/hr * 24 hr/day) = 2880 blocks. |
 | options | `Object` | Optional options |
 | options.allowDuplicates | `Boolean` | Allows duplicate proposals to be created. Unless this flag is set, you will not be able to make more than one deal per piece per miner. This protection exists to prevent erroneous duplicate deals. This parameter is not required. |
 | options.signal | [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) | A signal that can be used to abort the request |
@@ -470,13 +470,11 @@ console.log(payments)
 
 #### Example
 
-From a buffer:
-
 ```js
-const miner = "t2u2r6nyaxdspozci5t2i2xtfw23lxa35rvkul7di"
-const cid = "QmV9mkND7mvWim77R669UCLg1DgYzqiX1NsXtj7GSydzD6"
-const askId = "0"
-const time = "2800" // 1 day
+const miner = 't2u2r6nyaxdspozci5t2i2xtfw23lxa35rvkul7di'
+const cid = 'QmV9mkND7mvWim77R669UCLg1DgYzqiX1NsXtj7GSydzD6'
+const askId = '0'
+const time = 2800 // 1 day
 
 const storageDealProposal = await fc.client.proposeStorageDeal(miner, cid, askId, time)
 
@@ -485,14 +483,11 @@ const storageDealProposal = await fc.client.proposeStorageDeal(miner, cid, askId
 
 /*
 {
-  "state":3,
-  "message":"",
-  "proposalCid":
-    {
-      "/":"zDPWYqFCz8vQRUnFVsbdXPAWTRuRBLaPncKLLSqd7cNF3Bd2NQT5"
-    },
-  "proofInfo":null,
-  "signature":"c2lnbmF0dXJycmVlZQ=="
+  "state": 3,
+  "message": "",
+  "proposalCid": "zDPWYqFCz8vQRUnFVsbdXPAWTRuRBLaPncKLLSqd7cNF3Bd2NQT5",
+  "proofInfo": null,
+  "signature": "c2lnbmF0dXJycmVlZQ=="
 }
 */
 ```

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ $ filecoin config api.accessControlAllowOrigin '["http://example.com"]'
 * [client.import](API.md#clientimport)
 * [client.listAsks](API.md#clientlistasks)
 * [client.payments](API.md#clientpayments)
-* client.proposeStorageDeal
+* [client.proposeStorageDeal](API.md#clientproposestoragedeal)
 * client.queryStorageDeal
 * [config.get](API.md#configget)
 * [config.set](API.md#configset)

--- a/src/cmd/client/propose-storage-deal.js
+++ b/src/cmd/client/propose-storage-deal.js
@@ -6,15 +6,21 @@ const QueryString = require('querystring')
 module.exports = (fetch, config) => {
   return async (miner, cid, askId, time, options) => {
     options = options || {}
-    const args = { arg: [miner, cid, askId, time] }
-    const allowDuplicates = options.allowDuplicates ? { "allow-duplicates": options.allowDuplicates } : {}
 
-    const qs = Object.assign(args, allowDuplicates)
+    const qs = { arg: [miner, cid, askId, time] }
+    if (options.allowDuplicates != null) qs['allow-duplicates'] = options.allowDuplicates
 
-    const url = `${toUri(config.apiAddr)}/api/client/proposeStorageDeal?${QueryString.stringify(qs)}`
+    const url = `${toUri(config.apiAddr)}/api/client/propose-storage-deal?${QueryString.stringify(qs)}`
     const res = await ok(fetch(url, { signal: options.signal }))
 
-    const newDeal = await res.json()
-    return toCamel(newDeal)
+    const newDeal = toCamel(await res.json())
+
+    if (newDeal.proposalCid) {
+      newDeal.proposalCid = newDeal.proposalCid['/']
+    }
+
+    newDeal.proofInfo = toCamel(newDeal.proofInfo)
+
+    return newDeal
   }
 }

--- a/src/cmd/client/propose-storage-deal.js
+++ b/src/cmd/client/propose-storage-deal.js
@@ -2,9 +2,7 @@ const toUri = require('../../lib/multiaddr-to-uri')
 const { ok } = require('../../lib/fetch')
 
 module.exports = (fetch, config) => {
-  return async (miner, cid, askId, time, ...props) => {
-    const { allowDuplicates } = props[0] || []
-    let options = props.length > 1 ? props[1] : props[0]
+  return async (miner, cid, askId, time, options) => {
     options = options || {}
 
     miner = encodeURIComponent(miner)
@@ -12,7 +10,7 @@ module.exports = (fetch, config) => {
     askId = encodeURIComponent(askId)
     time = encodeURIComponent(time)
 
-    const duplicatesParam = allowDuplicates ? `&allow-duplicates=${encodeURIComponent(allowDuplicates)}` : ""
+    const duplicatesParam = options.allowDuplicates ? `&allow-duplicates=${encodeURIComponent(options.allowDuplicates)}` : ""
 
     const url = `${toUri(config.apiAddr)}/api/client/proposeStorageDeal?arg=${miner}&arg=${cid}&arg${askId}&arg${time}${duplicatesParam}`
     const res = await ok(fetch(url, { signal: options.signal }))

--- a/src/cmd/client/propose-storage-deal.js
+++ b/src/cmd/client/propose-storage-deal.js
@@ -1,0 +1,23 @@
+const toUri = require('../../lib/multiaddr-to-uri')
+const { ok } = require('../../lib/fetch')
+
+module.exports = (fetch, config) => {
+  return async (miner, cid, askId, time, ...props) => {
+    const { allowDuplicates } = props[0] || []
+    let options = props.length > 1 ? props[1] : props[0]
+    options = options || {}
+
+    miner = encodeURIComponent(miner)
+    cid = encodeURIComponent(cid)
+    askId = encodeURIComponent(askId)
+    time = encodeURIComponent(time)
+
+    const duplicatesParam = allowDuplicates ? `&allow-duplicates=${encodeURIComponent(allowDuplicates)}` : ""
+
+    const url = `${toUri(config.apiAddr)}/api/client/proposeStorageDeal?arg=${miner}&arg=${cid}&arg${askId}&arg${time}${duplicatesParam}`
+    const res = await ok(fetch(url, { signal: options.signal }))
+
+    const newDeal = await res.json()
+    return newDeal
+  }
+}

--- a/src/cmd/client/propose-storage-deal.js
+++ b/src/cmd/client/propose-storage-deal.js
@@ -1,21 +1,20 @@
 const toUri = require('../../lib/multiaddr-to-uri')
 const { ok } = require('../../lib/fetch')
+const toCamel = require('../../lib/to-camel')
+const QueryString = require('querystring')
 
 module.exports = (fetch, config) => {
   return async (miner, cid, askId, time, options) => {
     options = options || {}
+    const args = { arg: [miner, cid, askId, time] }
+    const allowDuplicates = options.allowDuplicates ? { "allow-duplicates": options.allowDuplicates } : {}
 
-    miner = encodeURIComponent(miner)
-    cid = encodeURIComponent(cid)
-    askId = encodeURIComponent(askId)
-    time = encodeURIComponent(time)
+    const qs = Object.assign(args, allowDuplicates)
 
-    const duplicatesParam = options.allowDuplicates ? `&allow-duplicates=${encodeURIComponent(options.allowDuplicates)}` : ""
-
-    const url = `${toUri(config.apiAddr)}/api/client/proposeStorageDeal?arg=${miner}&arg=${cid}&arg${askId}&arg${time}${duplicatesParam}`
+    const url = `${toUri(config.apiAddr)}/api/client/proposeStorageDeal?${QueryString.stringify(qs)}`
     const res = await ok(fetch(url, { signal: options.signal }))
 
     const newDeal = await res.json()
-    return newDeal
+    return toCamel(newDeal)
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,8 @@ module.exports = (fetch, config) => {
       cat: require('./cmd/client/cat')(fetch, config),
       import: require('./cmd/client/import')(fetch, config),
       listAsks: require('./cmd/client/list-asks')(fetch, config),
-      payments: require('./cmd/client/payments')(fetch, config)
+      payments: require('./cmd/client/payments')(fetch, config),
+      proposeStorageDeal: require('./cmd/client/propose-storage-deal')(fetch, config)
     },
     config: {
       get: require('./cmd/config/get')(fetch, config),

--- a/test/unit/cmd/client/propose-storage-deal.fixtures.json
+++ b/test/unit/cmd/client/propose-storage-deal.fixtures.json
@@ -1,0 +1,12 @@
+{
+  "sample0": {
+    "State": 3,
+    "Message": "",
+    "ProposalCid":
+      {
+        "/": "zDPWYqFCz8vQRUnFVsbdXPAWTRuRBLaPncKLLSqd7cNF3Bd2NQT5"
+      },
+    "ProofInfo": null,
+    "Signature": "c2lnbmF0dXJycmVlZQ=="
+  }
+}

--- a/test/unit/cmd/client/propose-storage-deal.test.js
+++ b/test/unit/cmd/client/propose-storage-deal.test.js
@@ -7,7 +7,7 @@ test('should propose a storage deal', async t => {
   const askId = "0"
   const time = "2880"
 
-  const newStorageDeal = {
+  const returnedStorageDeal = {
     "State":3,
     "Message":"",
     "ProposalCid":
@@ -18,12 +18,23 @@ test('should propose a storage deal', async t => {
     "Signature":"c2lnbmF0dXJycmVlZQ=="
   }
 
-  const fetch = () => ({ ok: true, json: () => newStorageDeal })
+  const toCamelStorageDeal = {
+    "state":3,
+    "message":"",
+    "proposalCid":
+      {
+        "/":"zDPWYqFCz8vQRUnFVsbdXPAWTRuRBLaPncKLLSqd7cNF3Bd2NQT5"
+      },
+    "proofInfo":null,
+    "signature":"c2lnbmF0dXJycmVlZQ=="
+  }
+
+  const fetch = () => ({ ok: true, json: () => returnedStorageDeal })
   const fc = Filecoin(fetch)
 
   const res = await fc.client.proposeStorageDeal(minerAddr, cid, askId, time)
 
-  t.is(res, newStorageDeal)
+  t.deepEqual(res, toCamelStorageDeal)
 })
 
 test('should allow proposal of a storage deal with allowDuplicates flag', async t => {
@@ -33,7 +44,7 @@ test('should allow proposal of a storage deal with allowDuplicates flag', async 
   const time = "2880"
   const options = { signal: "some signal", allowDuplicates: true }
 
-  const newStorageDeal = {
+  const returnedStorageDeal = {
     "State":3,
     "Message":"",
     "ProposalCid":
@@ -44,10 +55,21 @@ test('should allow proposal of a storage deal with allowDuplicates flag', async 
     "Signature":"c2lnbmF0dXJycmVlZQ=="
   }
 
-  const fetch = () => ({ ok: true, json: () => newStorageDeal })
+  const toCamelStorageDeal = {
+    "state":3,
+    "message":"",
+    "proposalCid":
+      {
+        "/":"zDPWYqFCz8vQRUnFVsbdXPAWTRuRBLaPncKLLSqd7cNF3Bd2NQT5"
+      },
+    "proofInfo":null,
+    "signature":"c2lnbmF0dXJycmVlZQ=="
+  }
+
+  const fetch = () => ({ ok: true, json: () => returnedStorageDeal })
   const fc = Filecoin(fetch)
 
   const res = await fc.client.proposeStorageDeal(minerAddr, cid, askId, time, options)
 
-  t.is(res, newStorageDeal)
+  t.deepEqual(res, toCamelStorageDeal)
 })

--- a/test/unit/cmd/client/propose-storage-deal.test.js
+++ b/test/unit/cmd/client/propose-storage-deal.test.js
@@ -1,0 +1,80 @@
+const test = require('ava')
+const Filecoin = require('../../../../src')
+
+test('should propose a storage deal', async t => {
+  const minerAddr = "t2u2r6nyaxdspozci5t2i2xtfw23lxa35rvkul7di"
+  const cid = "QmV9mkND7mvWim77R669UCLg1DgYzqiX1NsXtj7GSydzD6"
+  const askID = "0"
+  const time = "2880"
+
+  const newStorageDeal = {
+    "State":3,
+    "Message":"",
+    "ProposalCid":
+      {
+        "/":"zDPWYqFCz8vQRUnFVsbdXPAWTRuRBLaPncKLLSqd7cNF3Bd2NQT5"
+      },
+    "ProofInfo":null,
+    "Signature":"c2lnbmF0dXJycmVlZQ=="
+  }
+
+  const fetch = () => ({ ok: true, json: () => newStorageDeal })
+  const fc = Filecoin(fetch)
+
+  const res = await fc.client.proposeStorageDeal(minerAddr, cid, askID, time)
+
+  t.is(res, newStorageDeal)
+})
+
+test('should allow proposal of a storage deal with allowDuplicates flag', async t => {
+  const minerAddr = "t2u2r6nyaxdspozci5t2i2xtfw23lxa35rvkul7di"
+  const cid = "QmV9mkND7mvWim77R669UCLg1DgYzqiX1NsXtj7GSydzD6"
+  const askID = "0"
+  const time = "2880"
+  const allowDuplicates = true
+  const options = { signal: "some signal" }
+
+  const newStorageDeal = {
+    "State":3,
+    "Message":"",
+    "ProposalCid":
+      {
+        "/":"zDPWYqFCz8vQRUnFVsbdXPAWTRuRBLaPncKLLSqd7cNF3Bd2NQT5"
+      },
+    "ProofInfo":null,
+    "Signature":"c2lnbmF0dXJycmVlZQ=="
+  }
+
+  const fetch = () => ({ ok: true, json: () => newStorageDeal })
+  const fc = Filecoin(fetch)
+
+  const res = await fc.client.proposeStorageDeal(minerAddr, cid, askID, time, { allowDuplicates: allowDuplicates }, options)
+
+  t.is(res, newStorageDeal)
+})
+
+test('should handle proposing a storage deal with options and no allowDuplicates flag', async t => {
+  const minerAddr = "t2u2r6nyaxdspozci5t2i2xtfw23lxa35rvkul7di"
+  const cid = "QmV9mkND7mvWim77R669UCLg1DgYzqiX1NsXtj7GSydzD6"
+  const askID = "0"
+  const time = "2880"
+  const options = { signal: "some signal" }
+
+  const newStorageDeal = {
+    "State":3,
+    "Message":"",
+    "ProposalCid":
+      {
+        "/":"zDPWYqFCz8vQRUnFVsbdXPAWTRuRBLaPncKLLSqd7cNF3Bd2NQT5"
+      },
+    "ProofInfo":null,
+    "Signature":"c2lnbmF0dXJycmVlZQ=="
+  }
+
+  const fetch = () => ({ ok: true, json: () => newStorageDeal })
+  const fc = Filecoin(fetch)
+
+  const res = await fc.client.proposeStorageDeal(minerAddr, cid, askID, time, options)
+
+  t.is(res, newStorageDeal)
+})

--- a/test/unit/cmd/client/propose-storage-deal.test.js
+++ b/test/unit/cmd/client/propose-storage-deal.test.js
@@ -1,75 +1,44 @@
 const test = require('ava')
 const Filecoin = require('../../../../src')
+const Fixtures = require('./propose-storage-deal.fixtures.json')
 
 test('should propose a storage deal', async t => {
-  const minerAddr = "t2u2r6nyaxdspozci5t2i2xtfw23lxa35rvkul7di"
-  const cid = "QmV9mkND7mvWim77R669UCLg1DgYzqiX1NsXtj7GSydzD6"
-  const askId = "0"
-  const time = "2880"
+  const minerAddr = 't2u2r6nyaxdspozci5t2i2xtfw23lxa35rvkul7di'
+  const cid = 'QmV9mkND7mvWim77R669UCLg1DgYzqiX1NsXtj7GSydzD6'
+  const askId = '0'
+  const time = '2880'
 
-  const returnedStorageDeal = {
-    "State":3,
-    "Message":"",
-    "ProposalCid":
-      {
-        "/":"zDPWYqFCz8vQRUnFVsbdXPAWTRuRBLaPncKLLSqd7cNF3Bd2NQT5"
-      },
-    "ProofInfo":null,
-    "Signature":"c2lnbmF0dXJycmVlZQ=="
-  }
-
-  const toCamelStorageDeal = {
-    "state":3,
-    "message":"",
-    "proposalCid":
-      {
-        "/":"zDPWYqFCz8vQRUnFVsbdXPAWTRuRBLaPncKLLSqd7cNF3Bd2NQT5"
-      },
-    "proofInfo":null,
-    "signature":"c2lnbmF0dXJycmVlZQ=="
-  }
-
-  const fetch = () => ({ ok: true, json: () => returnedStorageDeal })
+  const fetch = () => ({ ok: true, json: () => Fixtures.sample0 })
   const fc = Filecoin(fetch)
 
   const res = await fc.client.proposeStorageDeal(minerAddr, cid, askId, time)
 
-  t.deepEqual(res, toCamelStorageDeal)
+  t.deepEqual(res, {
+    state: 3,
+    message: '',
+    proposalCid: 'zDPWYqFCz8vQRUnFVsbdXPAWTRuRBLaPncKLLSqd7cNF3Bd2NQT5',
+    proofInfo: null,
+    signature: 'c2lnbmF0dXJycmVlZQ=='
+  })
 })
 
 test('should allow proposal of a storage deal with allowDuplicates flag', async t => {
-  const minerAddr = "t2u2r6nyaxdspozci5t2i2xtfw23lxa35rvkul7di"
-  const cid = "QmV9mkND7mvWim77R669UCLg1DgYzqiX1NsXtj7GSydzD6"
-  const askId = "0"
-  const time = "2880"
-  const options = { signal: "some signal", allowDuplicates: true }
+  const minerAddr = 't2u2r6nyaxdspozci5t2i2xtfw23lxa35rvkul7di'
+  const cid = 'QmV9mkND7mvWim77R669UCLg1DgYzqiX1NsXtj7GSydzD6'
+  const askId = '0'
+  const time = '2880'
+  const options = { allowDuplicates: true }
 
-  const returnedStorageDeal = {
-    "State":3,
-    "Message":"",
-    "ProposalCid":
-      {
-        "/":"zDPWYqFCz8vQRUnFVsbdXPAWTRuRBLaPncKLLSqd7cNF3Bd2NQT5"
-      },
-    "ProofInfo":null,
-    "Signature":"c2lnbmF0dXJycmVlZQ=="
-  }
-
-  const toCamelStorageDeal = {
-    "state":3,
-    "message":"",
-    "proposalCid":
-      {
-        "/":"zDPWYqFCz8vQRUnFVsbdXPAWTRuRBLaPncKLLSqd7cNF3Bd2NQT5"
-      },
-    "proofInfo":null,
-    "signature":"c2lnbmF0dXJycmVlZQ=="
-  }
-
-  const fetch = () => ({ ok: true, json: () => returnedStorageDeal })
+  const fetch = () => ({ ok: true, json: () => Fixtures.sample0 })
   const fc = Filecoin(fetch)
 
   const res = await fc.client.proposeStorageDeal(minerAddr, cid, askId, time, options)
 
-  t.deepEqual(res, toCamelStorageDeal)
+  t.deepEqual(res, {
+    state: 3,
+    message: '',
+    proposalCid: 'zDPWYqFCz8vQRUnFVsbdXPAWTRuRBLaPncKLLSqd7cNF3Bd2NQT5',
+    proofInfo: null,
+    signature: 'c2lnbmF0dXJycmVlZQ=='
+  })
 })

--- a/test/unit/cmd/client/propose-storage-deal.test.js
+++ b/test/unit/cmd/client/propose-storage-deal.test.js
@@ -4,7 +4,7 @@ const Filecoin = require('../../../../src')
 test('should propose a storage deal', async t => {
   const minerAddr = "t2u2r6nyaxdspozci5t2i2xtfw23lxa35rvkul7di"
   const cid = "QmV9mkND7mvWim77R669UCLg1DgYzqiX1NsXtj7GSydzD6"
-  const askID = "0"
+  const askId = "0"
   const time = "2880"
 
   const newStorageDeal = {
@@ -21,7 +21,7 @@ test('should propose a storage deal', async t => {
   const fetch = () => ({ ok: true, json: () => newStorageDeal })
   const fc = Filecoin(fetch)
 
-  const res = await fc.client.proposeStorageDeal(minerAddr, cid, askID, time)
+  const res = await fc.client.proposeStorageDeal(minerAddr, cid, askId, time)
 
   t.is(res, newStorageDeal)
 })
@@ -29,10 +29,9 @@ test('should propose a storage deal', async t => {
 test('should allow proposal of a storage deal with allowDuplicates flag', async t => {
   const minerAddr = "t2u2r6nyaxdspozci5t2i2xtfw23lxa35rvkul7di"
   const cid = "QmV9mkND7mvWim77R669UCLg1DgYzqiX1NsXtj7GSydzD6"
-  const askID = "0"
+  const askId = "0"
   const time = "2880"
-  const allowDuplicates = true
-  const options = { signal: "some signal" }
+  const options = { signal: "some signal", allowDuplicates: true }
 
   const newStorageDeal = {
     "State":3,
@@ -48,33 +47,7 @@ test('should allow proposal of a storage deal with allowDuplicates flag', async 
   const fetch = () => ({ ok: true, json: () => newStorageDeal })
   const fc = Filecoin(fetch)
 
-  const res = await fc.client.proposeStorageDeal(minerAddr, cid, askID, time, { allowDuplicates: allowDuplicates }, options)
-
-  t.is(res, newStorageDeal)
-})
-
-test('should handle proposing a storage deal with options and no allowDuplicates flag', async t => {
-  const minerAddr = "t2u2r6nyaxdspozci5t2i2xtfw23lxa35rvkul7di"
-  const cid = "QmV9mkND7mvWim77R669UCLg1DgYzqiX1NsXtj7GSydzD6"
-  const askID = "0"
-  const time = "2880"
-  const options = { signal: "some signal" }
-
-  const newStorageDeal = {
-    "State":3,
-    "Message":"",
-    "ProposalCid":
-      {
-        "/":"zDPWYqFCz8vQRUnFVsbdXPAWTRuRBLaPncKLLSqd7cNF3Bd2NQT5"
-      },
-    "ProofInfo":null,
-    "Signature":"c2lnbmF0dXJycmVlZQ=="
-  }
-
-  const fetch = () => ({ ok: true, json: () => newStorageDeal })
-  const fc = Filecoin(fetch)
-
-  const res = await fc.client.proposeStorageDeal(minerAddr, cid, askID, time, options)
+  const res = await fc.client.proposeStorageDeal(minerAddr, cid, askId, time, options)
 
   t.is(res, newStorageDeal)
 })


### PR DESCRIPTION
Adds the ability to propose a storage deal

Issue [#15 ](https://github.com/filecoin-project/js-filecoin-api-client/issues/15)

**Endpoint**
`/api/client/propose-storage-deal`

**Description**
Propose a storage deal with a storage miner

**Arguments**
* arg [string]: Address of miner to send storage proposal Required: yes.
* arg [string]: CID of the data to be stored Required: yes.
* arg [string]: ID of ask for which to propose a deal Required: yes.
* arg [string]: Time in blocks (about 30 seconds per block) to store data Required: yes.
* allow-duplicates [bool]: Allows duplicate proposals to be created. Unless this flag is set, you will not be able to make more than one deal per piece per miner. This protection exists to prevent erroneous duplicate deals. Required: no.

**Response**
On success, the call to this endpoint will return with 200 and the following body:

```
{
  "State":7,
  "Message":"",
  "ProposalCid":
    {
      "/":"zDPWYqFD8CNXu7Mo9qPSUANbTK2vi9vJBnvavF9S1pVGPHafVHpT"
    },
  "ProofInfo":
    {
      "SectorID":1,
      "CommitmentMessage":
        {
          "/":"zDPWYqFCtHkWNkE2p6t6TeV1sPP5kbnKc5ajUhMVV8xvrw1u5F1R"
        },
      "PieceInclusionProof":"EiAbbOy4pChsCYqFYA6qJaUJYStlnwYMdQPHZX7YBkVXDD6vgmGTPnWrcdA9M0oAXQCzOq735YKySLUoTI6pAw=="
    },
  "Signature":"c2lnbmF0dXJycmVlZQ=="
}
```

resolves #15