### PR TITLE
perf: use URLSearchParams

### DIFF
--- a/src/cmd/client/propose-storage-deal.js
+++ b/src/cmd/client/propose-storage-deal.js
@@ -1,16 +1,16 @@
 const toUri = require('../../lib/multiaddr-to-uri')
 const { ok } = require('../../lib/fetch')
 const toCamel = require('../../lib/to-camel')
-const QueryString = require('querystring')
 
 module.exports = (fetch, config) => {
   return async (miner, cid, askId, time, options) => {
     options = options || {}
 
-    const qs = { arg: [miner, cid, askId, time] }
-    if (options.allowDuplicates != null) qs['allow-duplicates'] = options.allowDuplicates
+    const qs = new URLSearchParams(options.qs)
+    ;[miner, cid.toString(), askId, time].forEach(arg => qs.append('arg', arg))
+    if (options.allowDuplicates != null) qs.set('allow-duplicates', options.allowDuplicates)
 
-    const url = `${toUri(config.apiAddr)}/api/client/propose-storage-deal?${QueryString.stringify(qs)}`
+    const url = `${toUri(config.apiAddr)}/api/client/propose-storage-deal?${qs}`
     const res = await ok(fetch(url, { signal: options.signal }))
 
     const newDeal = toCamel(await res.json())

--- a/src/cmd/config/set.js
+++ b/src/cmd/config/set.js
@@ -1,6 +1,5 @@
 const toUri = require('../../lib/multiaddr-to-uri')
 const explain = require('explain-error')
-const QueryString = require('querystring')
 const { ok } = require('../../lib/fetch')
 
 module.exports = (fetch, config) => {
@@ -13,8 +12,10 @@ module.exports = (fetch, config) => {
       throw explain(err, 'failed to stringify config value')
     }
 
-    const qs = { arg: [key, value] }
-    const url = `${toUri(config.apiAddr)}/api/config?${QueryString.stringify(qs)}`
+    const qs = new URLSearchParams(options.qs)
+    ;[key, value].forEach(arg => qs.append('arg', arg))
+
+    const url = `${toUri(config.apiAddr)}/api/config?${qs}`
     const res = await ok(fetch(url, { signal: options.signal }))
     const data = await res.json()
     return data

--- a/src/cmd/dht/find-peer.js
+++ b/src/cmd/dht/find-peer.js
@@ -1,5 +1,4 @@
 const ndjson = require('iterable-ndjson')
-const QueryString = require('querystring')
 const toUri = require('../../lib/multiaddr-to-uri')
 const { ok, toIterable } = require('../../lib/fetch')
 
@@ -7,9 +6,10 @@ module.exports = (fetch, config) => {
   return (peerId, options) => (async function * () {
     options = options || {}
 
-    const qs = { arg: peerId }
+    const qs = new URLSearchParams(options.qs)
+    qs.set('arg', peerId.toString())
 
-    const url = `${toUri(config.apiAddr)}/api/dht/findpeer?${QueryString.stringify(qs)}`
+    const url = `${toUri(config.apiAddr)}/api/dht/findpeer?${qs}`
     const res = await ok(fetch(url, { signal: options.signal }))
 
     for await (const addr of ndjson(toIterable(res.body))) {

--- a/src/cmd/dht/find-provs.js
+++ b/src/cmd/dht/find-provs.js
@@ -1,5 +1,4 @@
 const ndjson = require('iterable-ndjson')
-const QueryString = require('querystring')
 const toUri = require('../../lib/multiaddr-to-uri')
 const { ok, toIterable } = require('../../lib/fetch')
 
@@ -7,13 +6,11 @@ module.exports = (fetch, config) => {
   return (key, options) => (async function * () {
     options = options || {}
 
-    const qs = { arg: key.toString() }
+    const qs = new URLSearchParams(options.qs)
+    qs.set('arg', key.toString())
+    if (options.numProviders) qs.set('num-providers', options.numProviders)
 
-    if (options.numProviders) {
-      qs['num-providers'] = options.numProviders
-    }
-
-    const url = `${toUri(config.apiAddr)}/api/dht/findprovs?${QueryString.stringify(qs)}`
+    const url = `${toUri(config.apiAddr)}/api/dht/findprovs?${qs}`
     const res = await ok(fetch(url, { signal: options.signal }))
 
     for await (const peer of ndjson(toIterable(res.body))) {

--- a/src/cmd/log/level.js
+++ b/src/cmd/log/level.js
@@ -1,18 +1,15 @@
 const toUri = require('../../lib/multiaddr-to-uri')
-const QueryString = require('querystring')
 const { ok } = require('../../lib/fetch')
 
 module.exports = (fetch, config) => {
   return async (level, options) => {
     options = options || {}
 
-    const qs = { arg: level }
+    const qs = new URLSearchParams(options.qs)
+    qs.set('arg', level)
+    if (options.subsystem) qs.set('subsystem', options.subsystem)
 
-    if (options.subsystem) {
-      qs.subsystem = options.subsystem
-    }
-
-    const url = `${toUri(config.apiAddr)}/api/log/level?${QueryString.stringify(qs)}`
+    const url = `${toUri(config.apiAddr)}/api/log/level?${qs}`
     const res = await ok(fetch(url, { signal: options.signal }))
     return res.json()
   }

--- a/src/cmd/message/wait.js
+++ b/src/cmd/message/wait.js
@@ -1,4 +1,3 @@
-const QueryString = require('querystring')
 const toUri = require('../../lib/multiaddr-to-uri')
 const { ok } = require('../../lib/fetch')
 const toCamel = require('../../lib/to-camel')
@@ -7,13 +6,14 @@ module.exports = (fetch, config) => {
   return async (messageCid, options) => {
     options = options || {}
 
-    const qs = { arg: messageCid.toString() }
-    if (options.message != null) qs.message = options.message
-    if (options.receipt != null) qs.receipt = options.receipt
-    if (options.return != null) qs.return = options.return
-    if (options.timeout) qs.timeout = options.timeout
+    const qs = new URLSearchParams(options.qs)
+    qs.set('arg', messageCid.toString())
+    if (options.message != null) qs.set('message', options.message)
+    if (options.receipt != null) qs.set('receipt', options.receipt)
+    if (options.return != null) qs.set('return', options.return)
+    if (options.timeout) qs.set('timeout', options.timeout)
 
-    const url = `${toUri(config.apiAddr)}/api/message/wait?${QueryString.stringify(qs)}`
+    const url = `${toUri(config.apiAddr)}/api/message/wait?${qs}`
     const res = await ok(fetch(url, { signal: options.signal }))
 
     return toCamel(await res.json())

--- a/src/cmd/miner/create.js
+++ b/src/cmd/miner/create.js
@@ -1,4 +1,3 @@
-const QueryString = require('querystring')
 const toUri = require('../../lib/multiaddr-to-uri')
 const { ok } = require('../../lib/fetch')
 
@@ -6,33 +5,34 @@ module.exports = (fetch, config) => {
   return async (collateral, options) => {
     options = options || {}
 
-    const qs = { arg: collateral }
+    const qs = new URLSearchParams(options.qs)
+    qs.set('arg', collateral)
 
     if (options.from != null) {
-      qs.from = options.from
+      qs.set('from', options.from)
     }
 
     if (options.gasLimit != null) {
-      qs['gas-limit'] = options.gasLimit
+      qs.set('gas-limit', options.gasLimit)
     }
 
     if (options.gasPrice != null) {
-      qs['gas-price'] = options.gasPrice
+      qs.set('gas-price', options.gasPrice)
     }
 
     if (options.peerId != null) {
-      qs.peerid = options.peerId
+      qs.set('peerid', options.peerId)
     }
 
     if (options.preview != null) {
-      qs.preview = options.preview
+      qs.set('preview', options.preview)
     }
 
     if (options.sectorSize != null) {
-      qs.sectorsize = options.sectorSize
+      qs.set('sectorsize', options.sectorSize)
     }
 
-    const url = `${toUri(config.apiAddr)}/api/miner/create?${QueryString.stringify(qs)}`
+    const url = `${toUri(config.apiAddr)}/api/miner/create?${qs}`
     const res = await ok(fetch(url, { signal: options.signal }))
     return res.json()
   }

--- a/src/cmd/ping.js
+++ b/src/cmd/ping.js
@@ -1,6 +1,5 @@
 const toUri = require('../lib/multiaddr-to-uri')
 const ndjson = require('iterable-ndjson')
-const QueryString = require('querystring')
 const { ok, toIterable } = require('../lib/fetch')
 const toCamel = require('../lib/to-camel')
 
@@ -8,13 +7,14 @@ module.exports = (fetch, config) => {
   return (peerId, options) => (async function * () {
     options = options || {}
 
-    const qs = { arg: peerId }
+    const qs = new URLSearchParams(options.qs)
+    qs.set('arg', peerId.toString())
 
     if (options.count != null) {
-      qs.count = options.count
+      qs.set('count', options.count)
     }
 
-    const url = `${toUri(config.apiAddr)}/api/ping?${QueryString.stringify(qs)}`
+    const url = `${toUri(config.apiAddr)}/api/ping?${qs}`
     const res = await ok(fetch(url, { signal: options.signal }))
 
     for await (const pong of ndjson(toIterable(res.body))) {

--- a/src/cmd/swarm/connect.js
+++ b/src/cmd/swarm/connect.js
@@ -1,4 +1,3 @@
-const QueryString = require('querystring')
 const toUri = require('../../lib/multiaddr-to-uri')
 const { ok } = require('../../lib/fetch')
 const toCamel = require('../../lib/to-camel')
@@ -8,9 +7,10 @@ module.exports = (fetch, config) => {
     addrs = Array.isArray(addrs) ? addrs : [addrs]
     options = options || {}
 
-    const qs = { arg: addrs.map(a => a.toString()) }
+    const qs = new URLSearchParams(options.qs)
+    addrs.forEach(a => qs.append('arg', a.toString()))
 
-    const url = `${toUri(config.apiAddr)}/api/swarm/connect?${QueryString.stringify(qs)}`
+    const url = `${toUri(config.apiAddr)}/api/swarm/connect?${qs}`
     const res = await ok(fetch(url, { signal: options.signal }))
     const data = await res.json()
 

--- a/src/cmd/swarm/peers.js
+++ b/src/cmd/swarm/peers.js
@@ -1,4 +1,3 @@
-const QueryString = require('querystring')
 const toUri = require('../../lib/multiaddr-to-uri')
 const { ok } = require('../../lib/fetch')
 const toCamel = require('../../lib/to-camel')
@@ -7,20 +6,20 @@ module.exports = (fetch, config) => {
   return async options => {
     options = options || {}
 
-    const qs = {}
+    const qs = new URLSearchParams(options.qs)
 
     if (options.verbose) {
-      qs.verbose = true
+      qs.set('verbose', true)
     } else {
       if (options.streams) {
-        qs.streams = true
+        qs.set('streams', true)
       }
       if (options.latency) {
-        qs.latency = true
+        qs.set('latency', true)
       }
     }
 
-    const url = `${toUri(config.apiAddr)}/api/swarm/peers?${QueryString.stringify(qs)}`
+    const url = `${toUri(config.apiAddr)}/api/swarm/peers?${qs}`
     const res = await ok(fetch(url, { signal: options.signal }))
     const data = await res.json()
 

--- a/src/cmd/wallet/export.js
+++ b/src/cmd/wallet/export.js
@@ -1,14 +1,18 @@
-const QueryString = require('querystring')
 const toUri = require('../../lib/multiaddr-to-uri')
 const { ok } = require('../../lib/fetch')
 const toCamel = require('../../lib/to-camel')
 
 module.exports = (fetch, config) => {
   return async (minerAddr, options) => {
+    minerAddr = Array.isArray(minerAddr) ? minerAddr : [minerAddr]
     options = options || {}
-    const qs = { arg: minerAddr }
-    const url = `${toUri(config.apiAddr)}/api/wallet/export?${QueryString.stringify(qs)}`
+
+    const qs = new URLSearchParams(options.qs)
+    minerAddr.forEach(a => qs.append('arg', a))
+
+    const url = `${toUri(config.apiAddr)}/api/wallet/export?${qs}`
     const res = await ok(fetch(url, { signal: options.signal }))
+
     return toCamel(await res.json())
   }
 }


### PR DESCRIPTION
Removes `querystring` from the bundle and makes it over 1KB smaller.

resolves https://github.com/filecoin-project/js-filecoin-api-client/issues/70